### PR TITLE
feat: add conversation folders to options dashboard

### DIFF
--- a/docs/feature-plan.md
+++ b/docs/feature-plan.md
@@ -26,7 +26,7 @@ This plan refines the high-level roadmap into concrete, traceable work items der
   - [ ] Bookmark pin toggle persists to storage.
 - [ ] Options dashboard foundations
   - [ ] Conversations table view (filter, sort by date).
-  - [ ] Folder tree sidebar (folders + subfolders).
+  - [x] Folder tree sidebar (folders + subfolders).
 
 **Test checklist**
 - Unit: text metric helpers, storage service (Vitest or manual Dexie smoke test).

--- a/src/core/storage/folders.ts
+++ b/src/core/storage/folders.ts
@@ -1,0 +1,125 @@
+import { db } from './db';
+import type { FolderRecord } from '@/core/models';
+
+export type FolderKind = FolderRecord['kind'];
+
+export interface CreateFolderInput {
+  name: string;
+  kind: FolderKind;
+  parentId?: string;
+}
+
+export interface FolderTreeNode extends FolderRecord {
+  children: FolderTreeNode[];
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+export async function createFolder(input: CreateFolderInput) {
+  const timestamp = nowIso();
+  const record: FolderRecord = {
+    id: crypto.randomUUID(),
+    name: input.name.trim(),
+    kind: input.kind,
+    parentId: input.parentId,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+
+  if (!record.name) {
+    throw new Error('Folder name is required');
+  }
+
+  await db.folders.put(record);
+  return record;
+}
+
+export async function renameFolder(folderId: string, name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('Folder name is required');
+  }
+
+  await db.folders.update(folderId, {
+    name: trimmed,
+    updatedAt: nowIso()
+  });
+}
+
+function buildTree(folders: FolderRecord[]): FolderTreeNode[] {
+  const nodes = folders.map<FolderTreeNode>((folder) => ({
+    ...folder,
+    children: []
+  }));
+
+  const byId = new Map<string, FolderTreeNode>();
+  nodes.forEach((node) => byId.set(node.id, node));
+
+  const roots: FolderTreeNode[] = [];
+  nodes.forEach((node) => {
+    if (node.parentId && byId.has(node.parentId)) {
+      byId.get(node.parentId)!.children.push(node);
+      return;
+    }
+    roots.push(node);
+  });
+
+  const sortNodes = (list: FolderTreeNode[]) => {
+    list.sort((a, b) => a.name.localeCompare(b.name));
+    list.forEach((child) => sortNodes(child.children));
+  };
+
+  sortNodes(roots);
+  return roots;
+}
+
+export async function getFolderTree(kind: FolderKind): Promise<FolderTreeNode[]> {
+  const folders = await db.folders.where('kind').equals(kind).toArray();
+  return buildTree(folders);
+}
+
+export async function deleteFolder(folderId: string) {
+  await db.transaction('rw', db.folders, db.conversations, async () => {
+    const allFolders = await db.folders.toArray();
+    const byParent = new Map<string | undefined, FolderRecord[]>();
+    for (const folder of allFolders) {
+      const key = folder.parentId;
+      const group = byParent.get(key) ?? [];
+      group.push(folder);
+      byParent.set(key, group);
+    }
+
+    const toDelete = new Set<string>();
+    const collect = (id: string) => {
+      if (toDelete.has(id)) {
+        return;
+      }
+      toDelete.add(id);
+      const children = byParent.get(id) ?? [];
+      children.forEach((child) => collect(child.id));
+    };
+
+    collect(folderId);
+
+    if (toDelete.size === 0) {
+      return;
+    }
+
+    const ids = Array.from(toDelete);
+    await db.folders.bulkDelete(ids);
+    await db.conversations
+      .where('folderId')
+      .anyOf(ids)
+      .modify({ folderId: undefined, updatedAt: nowIso() });
+  });
+}
+
+export async function listFolders(kind: FolderKind) {
+  return db.folders.where('kind').equals(kind).toArray();
+}
+
+export function buildFolderTree(folders: FolderRecord[]): FolderTreeNode[] {
+  return buildTree(folders);
+}

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -1,4 +1,4 @@
-﻿export * from './db';
+export * from './db';
 export * from './conversations';
+export * from './folders';
 export * from './syncBridge';
-

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,8 +1,11 @@
-﻿import { useEffect } from 'react';
+import type { ReactElement } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { togglePinned } from '@/core/storage';
+import type { FolderTreeNode } from '@/core/storage';
+import { createFolder, deleteFolder, togglePinned } from '@/core/storage';
 import { useRecentConversations } from '@/shared/hooks/useRecentConversations';
+import { useFolderTree } from '@/shared/hooks/useFolderTree';
 import { initI18n } from '@/shared/i18n';
 import { useSettingsStore } from '@/shared/state/settingsStore';
 
@@ -37,6 +40,8 @@ export function Options() {
   const { t } = useTranslation();
   const { direction } = useSettingsStore();
   const conversations = useRecentConversations(20);
+  const folderTree = useFolderTree('conversation');
+  const [folderName, setFolderName] = useState('');
 
   useEffect(() => {
     initI18n();
@@ -50,6 +55,64 @@ export function Options() {
     await togglePinned(conversationId);
   };
 
+  const handleCreateFolder = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = folderName.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    try {
+      await createFolder({
+        name: trimmed,
+        kind: 'conversation'
+      });
+      setFolderName('');
+    } catch (error) {
+      console.error('[ai-companion] failed to create folder', error);
+    }
+  };
+
+  const handleDeleteFolder = async (folderId: string) => {
+    try {
+      await deleteFolder(folderId);
+    } catch (error) {
+      console.error('[ai-companion] failed to delete folder', error);
+    }
+  };
+
+  const renderNodes = (nodes: FolderTreeNode[]): ReactElement => (
+    <ul className="space-y-1" role="group">
+      {nodes.map((node) => (
+        <li key={node.id} className="space-y-1" role="treeitem" aria-expanded={node.children.length > 0}>
+          <div className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100">
+            <span className="truncate" title={node.name}>
+              {node.name}
+            </span>
+            <button
+              className="text-xs font-medium text-emerald-300 hover:text-emerald-200"
+              onClick={() => handleDeleteFolder(node.id)}
+              type="button"
+            >
+              {t('options.deleteFolder')}
+            </button>
+          </div>
+          {node.children.length > 0 ? (
+            <div className="ml-4 border-l border-slate-800 pl-3" role="group">
+              {renderNodes(node.children)}
+            </div>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+
+  const treeContent = folderTree.length === 0 ? (
+    <p className="text-sm text-slate-300">{t('options.folderEmpty')}</p>
+  ) : (
+    renderNodes(folderTree)
+  );
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100" dir={direction}>
       <header className="border-b border-slate-800 bg-slate-900/60">
@@ -61,60 +124,93 @@ export function Options() {
       </header>
 
       <main className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
-        <section className="space-y-4">
-          <header>
-            <h2 className="text-lg font-semibold text-emerald-300">{t('options.conversationHeading')}</h2>
-            <p className="text-sm text-slate-300">{t('options.conversationDescription')}</p>
-          </header>
-          <div className="overflow-hidden rounded-xl border border-slate-800">
-            <table className="min-w-full divide-y divide-slate-800 text-sm">
-              <thead className="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-400">
-                <tr>
-                  <th className="px-4 py-3">Title</th>
-                  <th className="px-4 py-3">{t('popup.messages')}</th>
-                  <th className="px-4 py-3">{t('popup.words')}</th>
-                  <th className="px-4 py-3">{t('popup.characters')}</th>
-                  <th className="px-4 py-3">Updated</th>
-                  <th className="px-4 py-3 text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-900/60">
-                {conversations.length === 0 ? (
+        <section className="flex flex-col gap-6 md:flex-row">
+          <aside className="md:w-64">
+            <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+              <header className="space-y-1">
+                <h2 className="text-base font-semibold text-emerald-300">{t('options.folderHeading')}</h2>
+                <p className="text-xs text-slate-400">{t('options.folderDescription')}</p>
+              </header>
+              <form className="flex flex-col gap-2" onSubmit={handleCreateFolder}>
+                <label className="text-xs font-medium uppercase tracking-wide text-slate-400" htmlFor="new-folder-name">
+                  {t('options.addFolder')}
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+                    id="new-folder-name"
+                    placeholder={t('options.folderNamePlaceholder') ?? ''}
+                    value={folderName}
+                    onChange={(event) => setFolderName(event.target.value)}
+                  />
+                  <button
+                    className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
+                    type="submit"
+                  >
+                    {t('options.addFolderButton')}
+                  </button>
+                </div>
+              </form>
+              <div className="space-y-2" role="tree" aria-label={t('options.folderHeading')}>
+                {treeContent}
+              </div>
+            </div>
+          </aside>
+          <div className="flex-1 space-y-4">
+            <header>
+              <h2 className="text-lg font-semibold text-emerald-300">{t('options.conversationHeading')}</h2>
+              <p className="text-sm text-slate-300">{t('options.conversationDescription')}</p>
+            </header>
+            <div className="overflow-hidden rounded-xl border border-slate-800">
+              <table className="min-w-full divide-y divide-slate-800 text-sm">
+                <thead className="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-400">
                   <tr>
-                    <td className="px-4 py-6 text-center text-sm text-slate-400" colSpan={6}>
-                      {t('options.conversationEmpty')}
-                    </td>
+                    <th className="px-4 py-3">{t('options.columnTitle')}</th>
+                    <th className="px-4 py-3">{t('popup.messages')}</th>
+                    <th className="px-4 py-3">{t('popup.words')}</th>
+                    <th className="px-4 py-3">{t('popup.characters')}</th>
+                    <th className="px-4 py-3">{t('options.columnUpdated')}</th>
+                    <th className="px-4 py-3 text-right">{t('options.columnActions')}</th>
                   </tr>
-                ) : (
-                  conversations.map((conversation) => (
-                    <tr key={conversation.id} className="bg-slate-900/30">
-                      <td className="px-4 py-3">
-                        <div className="flex flex-col">
-                          <span className="font-medium text-slate-100">
-                            {conversation.title || 'Untitled conversation'}
-                          </span>
-                          <span className="text-xs text-slate-400">
-                            {conversation.pinned ? t('popup.unpin') : t('popup.pin')}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-4 py-3">{formatNumber(conversation.messageCount)}</td>
-                      <td className="px-4 py-3">{formatNumber(conversation.wordCount)}</td>
-                      <td className="px-4 py-3">{formatNumber(conversation.charCount)}</td>
-                      <td className="px-4 py-3 text-slate-300">{formatDate(conversation.updatedAt)}</td>
-                      <td className="px-4 py-3 text-right">
-                        <button
-                          className="rounded-full border border-slate-700 bg-slate-800 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
-                          onClick={() => handlePinToggle(conversation.id)}
-                        >
-                          {conversation.pinned ? t('popup.unpin') : t('popup.pin')}
-                        </button>
+                </thead>
+                <tbody className="divide-y divide-slate-900/60">
+                  {conversations.length === 0 ? (
+                    <tr>
+                      <td className="px-4 py-6 text-center text-sm text-slate-400" colSpan={6}>
+                        {t('options.conversationEmpty')}
                       </td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
+                  ) : (
+                    conversations.map((conversation) => (
+                      <tr key={conversation.id} className="bg-slate-900/30">
+                        <td className="px-4 py-3">
+                          <div className="flex flex-col">
+                            <span className="font-medium text-slate-100">
+                              {conversation.title || t('options.untitledConversation')}
+                            </span>
+                            <span className="text-xs text-slate-400">
+                              {conversation.pinned ? t('popup.unpin') : t('popup.pin')}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">{formatNumber(conversation.messageCount)}</td>
+                        <td className="px-4 py-3">{formatNumber(conversation.wordCount)}</td>
+                        <td className="px-4 py-3">{formatNumber(conversation.charCount)}</td>
+                        <td className="px-4 py-3 text-slate-300">{formatDate(conversation.updatedAt)}</td>
+                        <td className="px-4 py-3 text-right">
+                          <button
+                            className="rounded-full border border-slate-700 bg-slate-800 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+                            onClick={() => handlePinToggle(conversation.id)}
+                          >
+                            {conversation.pinned ? t('popup.unpin') : t('popup.pin')}
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
 

--- a/src/shared/hooks/useFolderTree.ts
+++ b/src/shared/hooks/useFolderTree.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { liveQuery } from 'dexie';
+
+import type { FolderKind, FolderTreeNode } from '@/core/storage';
+import { getFolderTree } from '@/core/storage';
+
+export function useFolderTree(kind: FolderKind) {
+  const [tree, setTree] = useState<FolderTreeNode[]>([]);
+
+  useEffect(() => {
+    const subscription = liveQuery(() => getFolderTree(kind)).subscribe({
+      next: (value) => setTree(value),
+      error: (error) => console.error('[ai-companion] folder tree subscription failed', error)
+    });
+
+    return () => subscription.unsubscribe();
+  }, [kind]);
+
+  return tree;
+}

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -25,6 +25,17 @@
     "comingSoon": "Detailed management views arrive in upcoming iterations.",
     "conversationHeading": "Conversation overview",
     "conversationDescription": "Latest chats captured from ChatGPT (stored locally).",
-    "conversationEmpty": "No conversations captured yet."
+    "conversationEmpty": "No conversations captured yet.",
+    "folderHeading": "Conversation folders",
+    "folderDescription": "Organize chats by project, topic, or workflow.",
+    "folderEmpty": "No folders yet. Create one to start grouping conversations.",
+    "addFolder": "Add folder",
+    "addFolderButton": "Create",
+    "folderNamePlaceholder": "Folder name",
+    "deleteFolder": "Remove",
+    "columnTitle": "Title",
+    "columnUpdated": "Updated",
+    "columnActions": "Actions",
+    "untitledConversation": "Untitled conversation"
   }
 }

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -25,6 +25,17 @@
     "comingSoon": "Uitgebreide beheerpagina's volgen in de komende iteraties.",
     "conversationHeading": "Overzicht van gesprekken",
     "conversationDescription": "Laatste chats vastgelegd vanuit ChatGPT (lokaal opgeslagen).",
-    "conversationEmpty": "Nog geen gesprekken vastgelegd."
+    "conversationEmpty": "Nog geen gesprekken vastgelegd.",
+    "folderHeading": "Gespreksmappen",
+    "folderDescription": "Organiseer chats per project, onderwerp of workflow.",
+    "folderEmpty": "Nog geen mappen. Maak er een om gesprekken te groeperen.",
+    "addFolder": "Map toevoegen",
+    "addFolderButton": "Aanmaken",
+    "folderNamePlaceholder": "Naam van map",
+    "deleteFolder": "Verwijderen",
+    "columnTitle": "Titel",
+    "columnUpdated": "Bijgewerkt",
+    "columnActions": "Acties",
+    "untitledConversation": "Naamloos gesprek"
   }
 }


### PR DESCRIPTION
## Summary
- add Dexie helpers for creating, listing, and removing conversation folders
- surface a live-updating folder tree with creation controls in the options dashboard
- localize new UI strings and record roadmap progress for the folder tree milestone

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dfb4d5a2c083338d08f2250eecc143