### PR TITLE
Fix npm build errors and document required checks

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -22,7 +22,7 @@ Guidelines for agents contributing to the AI ChatGPT Companion extension.
 - Keep localization keys in `src/shared/i18n/locales/{lang}/common.json`; update both EN and NL.
 
 ## 4. Testing & QA
-- Minimum: run `npm run lint` before submitting changes.
+- Minimum: run `npm run lint` and `npm run build` before submitting changes.
 - Add unit tests (Vitest) as new services are introduced; document gaps when skipping tests.
 - For DOM integrations, test against both `https://chat.openai.com` and `https://chatgpt.com`.
 - Document manual test steps in PR descriptions when automated coverage is missing.
@@ -36,6 +36,7 @@ Guidelines for agents contributing to the AI ChatGPT Companion extension.
 ## 6. Review Checklist
 Before requesting review:
 - [ ] `npm run lint` passes.
+- [ ] `npm run build` succeeds.
 - [ ] Feature aligns with milestone goals.
 - [ ] Localization + RTL considerations addressed.
 - [ ] Tests updated or rationale provided.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "ai-browser-extension",
   "version": "0.1.0",
   "description": "Chrome/Edge extension that enhances ChatGPT workflows with audio tools and advanced conversation management.",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/src/core/utils/textMetrics.ts
+++ b/src/core/utils/textMetrics.ts
@@ -1,9 +1,9 @@
-﻿export interface TextMetrics {
+export interface TextMetrics {
   wordCount: number;
   charCount: number;
 }
 
-const WORD_REGEX = /\p{L}+[\p{L}\p{Mn}\p{Pd}\']*/gu;
+const WORD_REGEX = new RegExp("\\p{L}+[\\p{L}\\p{Mn}\\p{Pd}\\']*", 'gu');
 
 function countWords(text: string) {
   const matches = text.match(WORD_REGEX);


### PR DESCRIPTION
## Summary
- remove the stray byte-order mark from package.json so tooling can parse the file as JSON
- convert the PostCSS config to an ES module to match the repository's module type
- wrap the Unicode word-matching pattern in textMetrics with a RegExp constructor to keep Rollup parsing happy
- update AGENT.md to require running both `npm run lint` and `npm run build` before submitting changes

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfcccdc7cc83339f6e5eed2cd6604b