### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ByteBrewerJB/AI-Browser-Extension/security/code-scanning/1](https://github.com/ByteBrewerJB/AI-Browser-Extension/security/code-scanning/1)

The recommended fix is to add an explicit `permissions` block to the workflow, limiting `GITHUB_TOKEN` permissions to the minimum required. Since the workflow only checks out code, installs dependencies, and runs build/test processes, it does not require write access to repository contents, so `contents: read` suffices. The best practice is to add this block at the workflow root (before `jobs:`), to apply to all jobs unless overridden. The change requires a single edit to `.github/workflows/ci.yml`: adding a `permissions:` block with `contents: read` after `name: CI` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
