### PR TITLE
fix: log messaging failures in console

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -20,11 +20,15 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   }
 
   if (info.menuItemId === 'ai-companion-bookmark-chat') {
-    chrome.tabs.sendMessage(tab.id, { type: 'bookmark-chat' }).catch(() => undefined);
+    chrome.tabs
+      .sendMessage(tab.id, { type: 'bookmark-chat' })
+      .catch((error) => console.error('[ai-companion] failed to send message', error));
   }
 
   if (info.menuItemId === 'ai-companion-save-audio') {
-    chrome.tabs.sendMessage(tab.id, { type: 'download-audio' }).catch(() => undefined);
+    chrome.tabs
+      .sendMessage(tab.id, { type: 'download-audio' })
+      .catch((error) => console.error('[ai-companion] failed to send message', error));
   }
 });
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -221,7 +221,9 @@ async function init() {
   observeLocationChanges();
   resetStateForConversation(getConversationId());
   await scanConversation();
-  chrome.runtime.sendMessage({ type: 'ping' }).catch(() => undefined);
+  chrome.runtime
+    .sendMessage({ type: 'ping' })
+    .catch((error) => console.error('[ai-companion] failed to send message', error));
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- log background context menu messaging failures with a console error prefix
- ensure content script ping failures surface console errors with matching messaging

## Testing
- npm run lint
- npm run build

## Manual Testing
- Not run (extension DevTools verification requires browser environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0c27671b88333aff7e8f3e082e7af