### PR TITLE
feat: add encrypted storage service

### DIFF
--- a/docs/architecture-roadmap.md
+++ b/docs/architecture-roadmap.md
@@ -36,6 +36,7 @@ This Chrome/Edge extension augments ChatGPT with richer conversation management,
   1. Browser-level sync using `chrome.storage.sync` for metadata (names, ids, timestamps) to enable multi-device awareness.
   2. Optional encrypted backup to user-selected provider (future enhancement) to fully share message bodies.
 - Metadata sync pipeline: conversation mutations trigger `syncBridge` updates (`src/core/storage/conversations.ts`), keeping counts/pin/archive state mirrored remotely.
+- Encryption & key management: IndexedDB tables track an `encryption` metadata record (Dexie v3) and the storage service provisions an AES-GCM key stored in `chrome.storage.local` only. The key never leaves the device, snapshots in `chrome.storage.sync` are encrypted with per-write salts, and future migrations can roll keys by bumping the metadata dataVersion and re-encrypting rows.
 - Search: build incremental index using MiniSearch stored in IndexedDB, refreshed per change batch.
 
 ## Accessibility & Localization

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -6,3 +6,4 @@ export * from './prompts';
 export * from './promptChains';
 export * from './settings';
 export * from './syncBridge';
+export * from './service';

--- a/src/core/storage/service.ts
+++ b/src/core/storage/service.ts
@@ -1,0 +1,340 @@
+import { db, ENCRYPTION_DATA_VERSION, ENCRYPTION_METADATA_KEY, type CompanionDatabase, type EncryptionMetadataValue, type MetadataRecord } from './db';
+
+const DEFAULT_SYNC_QUOTA_BYTES = 100 * 1024; // 100KB, Chrome documented limit per item.
+const ENCRYPTION_KEY_STORAGE_KEY = 'ai-companion:encryption:key';
+const DEFAULT_ENCRYPTION_CONTEXT = 'ai-companion';
+
+export interface EncryptedEnvelope<TVersion extends number = number> {
+  encryptionVersion: number;
+  payloadVersion: TVersion;
+  iv: string;
+  salt: string;
+  data: string;
+}
+
+export interface ReadEncryptedOptions<T> {
+  fallback: T;
+  expectedVersion: number;
+  upgrade?: (payload: unknown, version: number) => T;
+}
+
+export interface WriteEncryptedOptions<TVersion extends number = number> {
+  payloadVersion: TVersion;
+  quotaBytes?: number;
+}
+
+function getChromeStorageArea(area: 'sync' | 'local'): chrome.storage.StorageArea | undefined {
+  if (typeof chrome === 'undefined') {
+    return undefined;
+  }
+
+  return chrome.storage?.[area];
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buffer).toString('base64');
+  }
+
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(value: string): ArrayBuffer {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(value, 'base64')).buffer;
+  }
+
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function getCrypto(): Crypto {
+  if (!globalThis.crypto || !globalThis.crypto.subtle) {
+    throw new Error('WebCrypto is not available in this environment.');
+  }
+  return globalThis.crypto;
+}
+
+async function storageGet(area: 'sync' | 'local', key: string, fallbackStore: Map<string, unknown>) {
+  const storage = getChromeStorageArea(area);
+  if (!storage) {
+    if (!fallbackStore.has(key)) {
+      return undefined;
+    }
+    return { [key]: fallbackStore.get(key) } as Record<string, unknown>;
+  }
+
+  if ('get' in storage && storage.get.length === 1) {
+    return (storage.get as (keys: string) => Promise<Record<string, unknown>>)(key);
+  }
+
+  return new Promise<Record<string, unknown> | undefined>((resolve, reject) => {
+    try {
+      storage.get(key, (result) => {
+        const error = chrome.runtime?.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(result);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function storageSet(area: 'sync' | 'local', items: Record<string, unknown>, fallbackStore: Map<string, unknown>) {
+  const storage = getChromeStorageArea(area);
+  if (!storage) {
+    Object.entries(items).forEach(([key, value]) => {
+      fallbackStore.set(key, value);
+    });
+    return;
+  }
+
+  if ('set' in storage && storage.set.length === 1) {
+    await (storage.set as (items: Record<string, unknown>) => Promise<void>)(items);
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      storage.set(items, () => {
+        const error = chrome.runtime?.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function storageRemove(area: 'sync' | 'local', keys: string, fallbackStore: Map<string, unknown>) {
+  const storage = getChromeStorageArea(area);
+  if (!storage) {
+    fallbackStore.delete(keys);
+    return;
+  }
+
+  if ('remove' in storage && storage.remove.length === 1) {
+    await (storage.remove as (keys: string) => Promise<void>)(keys);
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      storage.remove(keys, () => {
+        const error = chrome.runtime?.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+export class StorageService {
+  private encryptionKeyPromise: Promise<CryptoKey> | null = null;
+
+  private readonly syncFallback: Map<string, unknown>;
+
+  private readonly localFallback: Map<string, unknown>;
+
+  constructor(private readonly database: CompanionDatabase, options?: { syncFallback?: Map<string, unknown>; localFallback?: Map<string, unknown> }) {
+    this.syncFallback = options?.syncFallback ?? new Map();
+    this.localFallback = options?.localFallback ?? new Map();
+  }
+
+  resetForTests() {
+    this.encryptionKeyPromise = null;
+    this.syncFallback.clear();
+    this.localFallback.clear();
+  }
+
+  async readEncryptionMetadata(): Promise<EncryptionMetadataValue> {
+    const existing = await this.database.metadata.get(ENCRYPTION_METADATA_KEY);
+    if (!existing) {
+      const now = new Date().toISOString();
+      const record: MetadataRecord<EncryptionMetadataValue> = {
+        key: ENCRYPTION_METADATA_KEY,
+        value: {
+          schemaVersion: 3,
+          dataVersion: 0,
+          pending: true
+        },
+        updatedAt: now
+      };
+      await this.database.metadata.put(record);
+      return record.value;
+    }
+    return existing.value as EncryptionMetadataValue;
+  }
+
+  async updateEncryptionMetadata(partial: Partial<EncryptionMetadataValue>) {
+    const current = await this.readEncryptionMetadata();
+    const now = new Date().toISOString();
+    const next: EncryptionMetadataValue = {
+      schemaVersion: Math.max(partial.schemaVersion ?? current.schemaVersion, current.schemaVersion),
+      dataVersion: partial.dataVersion ?? current.dataVersion,
+      lastMigrationAt: partial.lastMigrationAt ?? current.lastMigrationAt,
+      pending: partial.pending ?? current.pending
+    };
+
+    const record: MetadataRecord<EncryptionMetadataValue> = {
+      key: ENCRYPTION_METADATA_KEY,
+      value: next,
+      updatedAt: now
+    };
+    await this.database.metadata.put(record);
+  }
+
+  async readEncrypted<T>(key: string, options: ReadEncryptedOptions<T>): Promise<T> {
+    const raw = await storageGet('sync', key, this.syncFallback);
+    const envelope = raw?.[key] as EncryptedEnvelope | undefined;
+    if (!envelope) {
+      return options.fallback;
+    }
+
+    const decrypted = await this.decryptEnvelope(envelope, `${DEFAULT_ENCRYPTION_CONTEXT}:${key}`);
+    if (envelope.payloadVersion === options.expectedVersion) {
+      return decrypted as T;
+    }
+
+    if (options.upgrade) {
+      return options.upgrade(decrypted, envelope.payloadVersion);
+    }
+
+    return options.fallback;
+  }
+
+  async writeEncrypted<T>(key: string, value: T, options: WriteEncryptedOptions): Promise<void> {
+    const envelope = await this.encryptPayload(value, {
+      payloadVersion: options.payloadVersion,
+      context: `${DEFAULT_ENCRYPTION_CONTEXT}:${key}`
+    });
+
+    const serialized = JSON.stringify({ [key]: envelope });
+    const quota = options.quotaBytes ?? DEFAULT_SYNC_QUOTA_BYTES;
+    if (new TextEncoder().encode(serialized).byteLength > quota) {
+      throw new Error(`Sync payload for ${key} exceeds quota (${quota} bytes).`);
+    }
+
+    await storageSet('sync', { [key]: envelope }, this.syncFallback);
+  }
+
+  async removeEncrypted(key: string): Promise<void> {
+    await storageRemove('sync', key, this.syncFallback);
+  }
+
+  async decodeEnvelope<T>(input: unknown, key: string, options: ReadEncryptedOptions<T>): Promise<T> {
+    const envelope = input as EncryptedEnvelope | undefined;
+    if (!envelope) {
+      return options.fallback;
+    }
+
+    const decrypted = await this.decryptEnvelope(envelope, `${DEFAULT_ENCRYPTION_CONTEXT}:${key}`);
+    if (envelope.payloadVersion === options.expectedVersion) {
+      return decrypted as T;
+    }
+
+    if (options.upgrade) {
+      return options.upgrade(decrypted, envelope.payloadVersion);
+    }
+
+    return options.fallback;
+  }
+
+  private async getEncryptionKey(): Promise<CryptoKey> {
+    if (!this.encryptionKeyPromise) {
+      this.encryptionKeyPromise = this.loadOrCreateKey();
+    }
+    return this.encryptionKeyPromise;
+  }
+
+  private async loadOrCreateKey(): Promise<CryptoKey> {
+    const stored = await this.readLocal<string>(ENCRYPTION_KEY_STORAGE_KEY);
+    if (stored) {
+      return this.importKey(base64ToArrayBuffer(stored));
+    }
+
+    const crypto = getCrypto();
+    const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+    const exported = await crypto.subtle.exportKey('raw', key);
+    await this.writeLocal(ENCRYPTION_KEY_STORAGE_KEY, arrayBufferToBase64(exported));
+    return key;
+  }
+
+  private async readLocal<T>(key: string): Promise<T | undefined> {
+    const raw = await storageGet('local', key, this.localFallback);
+    if (!raw) {
+      return undefined;
+    }
+    return (raw[key] as T | undefined) ?? (raw as unknown as T);
+  }
+
+  private async writeLocal(key: string, value: unknown) {
+    await storageSet('local', { [key]: value }, this.localFallback);
+  }
+
+  private async encryptPayload(value: unknown, options: { context: string; payloadVersion: number }): Promise<EncryptedEnvelope> {
+    const crypto = getCrypto();
+    const key = await this.getEncryptionKey();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const encoder = new TextEncoder();
+    const plaintext = encoder.encode(JSON.stringify({ value, context: options.context, salt: Array.from(salt) }));
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext);
+
+    return {
+      encryptionVersion: ENCRYPTION_DATA_VERSION,
+      payloadVersion: options.payloadVersion,
+      iv: arrayBufferToBase64(iv.buffer),
+      salt: arrayBufferToBase64(salt.buffer),
+      data: arrayBufferToBase64(ciphertext)
+    };
+  }
+
+  private async decryptEnvelope(envelope: EncryptedEnvelope, context: string): Promise<unknown> {
+    if (envelope.encryptionVersion !== ENCRYPTION_DATA_VERSION) {
+      throw new Error(`Unsupported encryption version: ${envelope.encryptionVersion}`);
+    }
+
+    const crypto = getCrypto();
+    const key = await this.getEncryptionKey();
+    const iv = new Uint8Array(base64ToArrayBuffer(envelope.iv));
+    const ciphertext = base64ToArrayBuffer(envelope.data);
+    const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    const decoded = JSON.parse(new TextDecoder().decode(decrypted)) as { value: unknown; context: string; salt: number[] };
+
+    if (!decoded || decoded.context !== context) {
+      throw new Error('Decryption context mismatch.');
+    }
+
+    return decoded.value;
+  }
+
+  private async importKey(raw: ArrayBuffer): Promise<CryptoKey> {
+    const crypto = getCrypto();
+    return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+  }
+}
+
+export const storageService = new StorageService(db);

--- a/tests/conversationIngestion.spec.ts
+++ b/tests/conversationIngestion.spec.ts
@@ -5,6 +5,7 @@ import { computeTextMetrics, sumTextMetrics } from '@/core/utils/textMetrics';
 import type { MessageRecord } from '@/core/models';
 import { db, resetDatabase } from '@/core/storage/db';
 import type { SyncSnapshot } from '@/core/storage/syncBridge';
+import { storageService } from '@/core/storage/service';
 
 interface ChromeStorageChange {
   oldValue?: unknown;
@@ -149,13 +150,17 @@ async function prepareConversation(id: string, title: string) {
   return document;
 }
 
-function getSnapshot(): SyncSnapshot | undefined {
-  const key = 'ai-companion:snapshot:v1';
+async function getSnapshot(): Promise<SyncSnapshot | undefined> {
+  const key = 'ai-companion:snapshot:v2';
   const storage = (globalThis as any).__chromeStorageState as Record<string, unknown> | undefined;
-  if (!storage) {
+  if (!storage || !storage[key]) {
     return undefined;
   }
-  return storage[key] as SyncSnapshot | undefined;
+  return storageService.decodeEnvelope(storage[key], key, {
+    fallback: undefined,
+    expectedVersion: 2,
+    upgrade: (payload) => payload as SyncSnapshot
+  });
 }
 
 const tests: AsyncTest[] = [
@@ -190,7 +195,7 @@ const tests: AsyncTest[] = [
       const messageCount = await db.messages.where('conversationId').equals('system-test').count();
       assert.equal(messageCount, 3);
 
-      const snapshot = getSnapshot();
+      const snapshot = await getSnapshot();
       assert.ok(snapshot, 'sync snapshot should exist');
       const storedConversation = snapshot!.conversations['system-test'];
       assert.equal(storedConversation.wordCount, totals.wordCount);

--- a/tests/runAll.ts
+++ b/tests/runAll.ts
@@ -1,2 +1,3 @@
 import './promptChains.spec.ts';
 import './conversationIngestion.spec.ts';
+import './storageEncryption.spec.ts';

--- a/tests/storageEncryption.spec.ts
+++ b/tests/storageEncryption.spec.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+
+import { db, ENCRYPTION_METADATA_KEY, ENCRYPTION_DATA_VERSION, resetDatabase } from '@/core/storage/db';
+import type { SyncSnapshot } from '@/core/storage/syncBridge';
+import { StorageService } from '@/core/storage/service';
+
+type AsyncTest = [name: string, execute: () => Promise<void>];
+
+const baseSnapshot: SyncSnapshot = {
+  conversations: {},
+  version: 2,
+  updatedAt: '1970-01-01T00:00:00.000Z'
+};
+
+const tests: AsyncTest[] = [
+  [
+    'encrypts and decrypts payloads symmetrically',
+    async () => {
+      await resetDatabase();
+      const previousChrome = (globalThis as any).chrome;
+      // Ensure the storage service uses the in-memory fallbacks rather than a shared Chrome mock.
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as any).chrome;
+      try {
+        const syncFallback = new Map<string, unknown>();
+        const localFallback = new Map<string, unknown>();
+        const service = new StorageService(db, { syncFallback, localFallback });
+
+        const snapshot: SyncSnapshot = {
+          conversations: {
+            example: {
+              id: 'example',
+              updatedAt: '2024-01-01T00:00:00.000Z',
+              wordCount: 10,
+              charCount: 42,
+              pinned: true
+            }
+          },
+          version: 2,
+          updatedAt: '2024-01-01T00:00:00.000Z'
+        };
+
+        await service.writeEncrypted('test:key', snapshot, { payloadVersion: 2, quotaBytes: 2048 });
+
+        const storedEnvelope = syncFallback.get('test:key') as Record<string, unknown> | undefined;
+        assert.ok(storedEnvelope, 'ciphertext stored in sync fallback');
+        assert.notDeepEqual(storedEnvelope, snapshot);
+        assert.equal(storedEnvelope?.encryptionVersion, ENCRYPTION_DATA_VERSION);
+
+        const result = await service.readEncrypted('test:key', {
+          fallback: baseSnapshot,
+          expectedVersion: 2,
+          upgrade: (payload) => payload as SyncSnapshot
+        });
+
+        assert.deepEqual(result, snapshot);
+      } finally {
+        if (previousChrome !== undefined) {
+          (globalThis as any).chrome = previousChrome;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete (globalThis as any).chrome;
+        }
+      }
+    }
+  ],
+  [
+    'initializes encryption metadata on first open',
+    async () => {
+      await resetDatabase();
+      const previousChrome = (globalThis as any).chrome;
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as any).chrome;
+      try {
+        const service = new StorageService(db, { syncFallback: new Map(), localFallback: new Map() });
+
+        const before = await db.metadata.get(ENCRYPTION_METADATA_KEY);
+        assert.equal(before, undefined);
+
+        const metadata = await service.readEncryptionMetadata();
+        assert.equal(metadata.pending, true);
+
+        const stored = await db.metadata.get(ENCRYPTION_METADATA_KEY);
+        assert.ok(stored);
+        assert.deepEqual(stored?.value, metadata);
+      } finally {
+        if (previousChrome !== undefined) {
+          (globalThis as any).chrome = previousChrome;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete (globalThis as any).chrome;
+        }
+      }
+    }
+  ]
+];
+
+async function run() {
+  let hasFailure = false;
+
+  for (const [name, execute] of tests) {
+    try {
+      await execute();
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      hasFailure = true;
+      console.error(`✖ ${name}`);
+      console.error(error);
+    }
+  }
+
+  if (hasFailure) {
+    process.exitCode = 1;
+  }
+}
+
+await run();


### PR DESCRIPTION
## Summary
- add Dexie v3 metadata to track encryption status and schema upgrades
- create a WebCrypto-backed storage service that encrypts sync payloads and handles legacy snapshot migration
- update sync bridge consumers, tests, and docs to reflect encrypted snapshots and key management

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e1a567188333a16648906dad7e30