### PR TITLE
fix: load content overlay styles from shadow root

### DIFF
--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/ui/components/Modal';
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@/ui/components/Tabs';
-import '@/styles/global.css';
+import globalStylesUrl from '@/styles/global.css?url';
 
 function ensureShadowHost(): HTMLElement {
   const existing = document.getElementById('ai-companion-shadow-host');
@@ -32,6 +32,10 @@ function mountReact(rootElement: HTMLElement) {
     button { font: inherit; }
   `;
   shadow.appendChild(style);
+  const globalStyles = document.createElement('link');
+  globalStyles.rel = 'stylesheet';
+  globalStyles.href = globalStylesUrl;
+  shadow.appendChild(globalStyles);
   const container = document.createElement('div');
   shadow.appendChild(container);
   return shadow;

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css?url' {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
## Summary
- load the shared Tailwind bundle inside the content script shadow root so the overlay styles apply on ChatGPT
- declare the `*.css?url` module type used for importing the stylesheet URL

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0fc0fd17c83339d69b9037376f702