### PR TITLE
feat: localize content sidebar overlay

### DIFF
--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -1,9 +1,11 @@
 import React, { StrictMode, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { useTranslation } from 'react-i18next';
 
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/ui/components/Modal';
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@/ui/components/Tabs';
 import globalStylesUrl from '@/styles/global.css?url';
+import { initI18n } from '@/shared/i18n';
 
 const HOST_ID = 'ai-companion-shadow-host';
 
@@ -204,81 +206,74 @@ function mountReact(rootElement: HTMLElement) {
 function CompanionOverlay() {
   const [isModalOpen, setModalOpen] = useState(false);
   const [activeToolbar, setActiveToolbar] = useState<'history' | 'prompts' | 'media'>('history');
+  const { t } = useTranslation();
 
   const toolbarLabel = useMemo(() => {
-    switch (activeToolbar) {
-      case 'prompts':
-        return 'Prompt toolbox';
-      case 'media':
-        return 'Voice controls';
-      case 'history':
-      default:
-        return 'Conversation tools';
-    }
-  }, [activeToolbar]);
+    return t(`content.sidebar.toolbars.${activeToolbar}`);
+  }, [activeToolbar, t]);
+
+  const modalPoints = useMemo(() => {
+    return t('content.sidebar.modal.points', { returnObjects: true }) as string[];
+  }, [t]);
 
   return (
     <div className="pointer-events-auto w-full rounded-xl border border-slate-800 bg-slate-950/95 p-4 text-slate-100 shadow-xl">
       <header className="mb-4 flex items-center justify-between">
         <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-400">AI Companion</p>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-400">
+            {t('content.sidebar.title')}
+          </p>
           <h2 className="text-base font-semibold">{toolbarLabel}</h2>
         </div>
         <button
           className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+          aria-label={t('content.sidebar.patternButtonAria')}
           onClick={() => setModalOpen(true)}
           type="button"
         >
-          Patterns
+          {t('content.sidebar.patternButton')}
         </button>
       </header>
       <Tabs defaultValue="history" onChange={(value) => setActiveToolbar(value as typeof activeToolbar)}>
         <TabList className="mb-2 flex gap-2">
-          <Tab value="history">History</Tab>
-          <Tab value="prompts">Prompts</Tab>
-          <Tab value="media">Media</Tab>
+          <Tab value="history">{t('content.sidebar.tabs.history')}</Tab>
+          <Tab value="prompts">{t('content.sidebar.tabs.prompts')}</Tab>
+          <Tab value="media">{t('content.sidebar.tabs.media')}</Tab>
         </TabList>
         <TabPanels className="rounded-md border border-slate-800 bg-slate-900/60 p-3 text-sm text-slate-200">
           <TabPanel value="history">
-            <p>
-              Save and pin chats directly from the conversation view. Table presets created here sync with the dashboard.
-            </p>
+            <p>{t('content.sidebar.tabDescriptions.history')}</p>
           </TabPanel>
           <TabPanel value="prompts">
-            <p>
-              Build prompt chains inline, attach them to GPT folders, and reuse them across popup and options surfaces.
-            </p>
+            <p>{t('content.sidebar.tabDescriptions.prompts')}</p>
           </TabPanel>
           <TabPanel value="media">
-            <p>
-              Voice overlays reuse the shared modal + overlay primitives to ensure consistent focus management and styling.
-            </p>
+            <p>{t('content.sidebar.tabDescriptions.media')}</p>
           </TabPanel>
         </TabPanels>
       </Tabs>
       <Modal labelledBy="overlay-modal-heading" onClose={() => setModalOpen(false)} open={isModalOpen}>
         <ModalHeader>
           <h3 id="overlay-modal-heading" className="text-lg font-semibold text-slate-100">
-            Shared component library
+            {t('content.sidebar.modal.title')}
           </h3>
-          <p className="text-sm text-slate-300">
-            Modals, tabs, and overlays are rendered within a shadow root so styles do not collide with ChatGPT.
-          </p>
+          <p className="text-sm text-slate-300">{t('content.sidebar.modal.description')}</p>
         </ModalHeader>
         <ModalBody>
           <ul className="list-disc space-y-2 pl-6 text-sm text-slate-200">
-            <li>Keyboard shortcuts remain functional thanks to consistent escape handling.</li>
-            <li>All surfaces respect RTL layouts and localized labels from the shared i18n bundle.</li>
-            <li>Zustand domain stores hydrate content, popup, and options entries without prop drilling.</li>
+            {modalPoints.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
           </ul>
         </ModalBody>
         <ModalFooter>
           <button
             className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
+            aria-label={t('content.sidebar.modal.closeAria')}
             onClick={() => setModalOpen(false)}
             type="button"
           >
-            Close
+            {t('content.sidebar.modal.close')}
           </button>
         </ModalFooter>
       </Modal>
@@ -286,26 +281,26 @@ function CompanionOverlay() {
   );
 }
 
-function init() {
-  ensureShadowHost().then((host) => {
-    const shadow = mountReact(host);
-    const container = shadow.querySelector('div:last-of-type') as HTMLDivElement | null;
-    if (!container) {
-      throw new Error('Failed to initialize companion overlay container');
-    }
-    const root = createRoot(container);
-    root.render(
-      <StrictMode>
-        <CompanionOverlay />
-      </StrictMode>
-    );
-  });
+async function init() {
+  const host = await ensureShadowHost();
+  await initI18n();
+  const shadow = mountReact(host);
+  const container = shadow.querySelector('div:last-of-type') as HTMLDivElement | null;
+  if (!container) {
+    throw new Error('Failed to initialize companion overlay container');
+  }
+  const root = createRoot(container);
+  root.render(
+    <StrictMode>
+      <CompanionOverlay />
+    </StrictMode>
+  );
 }
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
-    init();
+    void init();
   });
 } else {
-  init();
+  void init();
 }

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -153,5 +153,38 @@
     "promptChainRemoveButton": "Remove",
     "promptChainUpdateButton": "Update chain",
     "promptChainCreateButton": "Save chain"
+  },
+  "content": {
+    "sidebar": {
+      "title": "AI Companion",
+      "patternButton": "Patterns",
+      "patternButtonAria": "Open pattern references",
+      "toolbars": {
+        "history": "Conversation tools",
+        "prompts": "Prompt toolbox",
+        "media": "Voice controls"
+      },
+      "tabs": {
+        "history": "History",
+        "prompts": "Prompts",
+        "media": "Media"
+      },
+      "tabDescriptions": {
+        "history": "Save and pin chats directly from the conversation view. Table presets created here sync with the dashboard.",
+        "prompts": "Build prompt chains inline, attach them to GPT folders, and reuse them across popup and options surfaces.",
+        "media": "Voice overlays reuse the shared modal + overlay primitives to ensure consistent focus management and styling."
+      },
+      "modal": {
+        "title": "Shared component library",
+        "description": "Modals, tabs, and overlays are rendered within a shadow root so styles do not collide with ChatGPT.",
+        "points": [
+          "Keyboard shortcuts remain functional thanks to consistent escape handling.",
+          "All surfaces respect RTL layouts and localized labels from the shared i18n bundle.",
+          "Zustand domain stores hydrate content, popup, and options entries without prop drilling."
+        ],
+        "close": "Close",
+        "closeAria": "Close modal"
+      }
+    }
   }
 }

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -153,5 +153,38 @@
     "promptChainRemoveButton": "Verwijderen",
     "promptChainUpdateButton": "Keten bijwerken",
     "promptChainCreateButton": "Keten opslaan"
+  },
+  "content": {
+    "sidebar": {
+      "title": "AI Companion",
+      "patternButton": "Patronen",
+      "patternButtonAria": "Patroonoverzicht openen",
+      "toolbars": {
+        "history": "Gesprekstools",
+        "prompts": "Prompt-toolbox",
+        "media": "Spraakbediening"
+      },
+      "tabs": {
+        "history": "Geschiedenis",
+        "prompts": "Prompts",
+        "media": "Media"
+      },
+      "tabDescriptions": {
+        "history": "Sla chats op en zet ze vast rechtstreeks vanuit de gespreksweergave. Tabelpresets die je hier maakt, worden gesynchroniseerd met het dashboard.",
+        "prompts": "Stel promptketens samen in de interface, koppel ze aan GPT-mappen en hergebruik ze in de popup- en optieschermen.",
+        "media": "Spraakoverlays hergebruiken de gedeelde modal- en overlay-primitieven voor consistente focusafhandeling en styling."
+      },
+      "modal": {
+        "title": "Gedeelde componentenbibliotheek",
+        "description": "Modals, tabbladen en overlays worden weergegeven binnen een shadow root zodat stijlen niet botsen met ChatGPT.",
+        "points": [
+          "Sneltoetsen blijven werken dankzij consistente escape-afhandeling.",
+          "Alle oppervlakken respecteren RTL-layouts en vertaalde labels uit het gedeelde i18n-pakket.",
+          "Zustand-domeinstores hydrateren content-, popup- en optieschermen zonder prop-drilling."
+        ],
+        "close": "Sluiten",
+        "closeAria": "Modal sluiten"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add localized content sidebar copy for the content script overlay
- initialize the content script i18n bundle before rendering and swap literals for translation lookups

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e106a1e8988333b71a4cfbb1fd7181