### PR TITLE
feat: integrate companion host into chat sidebar

### DIFF
--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, useMemo, useState } from 'react';
+import React, { StrictMode, useEffect, useId, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/ui/components/Modal';
@@ -22,36 +22,76 @@ const SIDEBAR_SELECTORS = [
   '[data-testid="left_sidebar"]',
 ];
 
+const SIDEBAR_LIST_CANDIDATES = [
+  'ol',
+  'ul',
+  '[role="list"]',
+  '[data-testid="nav-list"]',
+  '[data-testid="conversation-list"]',
+];
+
 let sidebarMutationObserver: MutationObserver | null = null;
 let sidebarResizeObserver: ResizeObserver | null = null;
-let observedSidebar: HTMLElement | null = null;
+let resizeObserverTarget: HTMLElement | null = null;
 let activeHost: HTMLElement | null = null;
 let locationWatcher: number | null = null;
 let lastKnownHref = typeof window !== 'undefined' ? window.location.href : '';
 
+function findListWithin(element: Element | null): HTMLElement | null {
+  if (!(element instanceof HTMLElement)) {
+    return null;
+  }
+
+  if (element.matches(SIDEBAR_LIST_CANDIDATES.join(', '))) {
+    return element;
+  }
+
+  for (const selector of SIDEBAR_LIST_CANDIDATES) {
+    const list = element.querySelector(selector);
+    if (list instanceof HTMLElement) {
+      return list;
+    }
+  }
+
+  return null;
+}
+
 function findSidebarContainer(): HTMLElement | null {
   for (const selector of SIDEBAR_SELECTORS) {
-    const nav = document.querySelector(selector) as HTMLElement | null;
-    if (nav) {
-      return nav.parentElement instanceof HTMLElement ? nav.parentElement : nav;
+    const candidate = document.querySelector(selector) as HTMLElement | null;
+    if (!candidate) {
+      continue;
+    }
+
+    const scope =
+      candidate.matches('nav, ol, ul, [role="list"]')
+        ? candidate
+        : (candidate.closest('nav, [data-testid="left-sidebar"], [data-testid="left_sidebar"]') as HTMLElement | null) ?? candidate;
+
+    const list = findListWithin(scope);
+    if (list) {
+      return list;
     }
   }
 
   const sidebarTestId = document.querySelector('[data-testid="left-sidebar"]');
-  if (sidebarTestId instanceof HTMLElement) {
-    return sidebarTestId;
+  const sidebarList = findListWithin(sidebarTestId);
+  if (sidebarList) {
+    return sidebarList;
   }
 
   const genericNav = document.querySelector(
-    'nav[aria-label*="history" i], nav[aria-label*="recent" i]',
+    'nav[aria-label*="history" i], nav[aria-label*="recent" i]'
   );
-  if (genericNav instanceof HTMLElement) {
-    return genericNav.parentElement instanceof HTMLElement ? genericNav.parentElement : genericNav;
+  const genericList = findListWithin(genericNav);
+  if (genericList) {
+    return genericList;
   }
 
-  const genericSidebar = document.querySelector('[data-testid*="sidebar" i]');
-  if (genericSidebar instanceof HTMLElement) {
-    return genericSidebar;
+  const fallbackSidebar = document.querySelector('[data-testid*="sidebar" i]');
+  const fallbackList = findListWithin(fallbackSidebar);
+  if (fallbackList) {
+    return fallbackList;
   }
 
   return null;
@@ -62,48 +102,57 @@ function ensureHostPlacement(): void {
     return;
   }
   const sidebar = findSidebarContainer();
-  const fallbackContainer = document.documentElement;
 
   if (!sidebar) {
-    activeHost.setAttribute('data-ai-companion-collapsed', 'true');
-    if (fallbackContainer && activeHost.parentElement !== fallbackContainer) {
-      fallbackContainer.appendChild(activeHost);
+    activeHost.setAttribute('data-ai-companion-hidden', 'true');
+    if (activeHost.parentElement) {
+      activeHost.remove();
     }
-    if (observedSidebar && sidebarResizeObserver) {
-      sidebarResizeObserver.unobserve(observedSidebar);
+    if (resizeObserverTarget && sidebarResizeObserver) {
+      sidebarResizeObserver.unobserve(resizeObserverTarget);
     }
-    observedSidebar = null;
+    resizeObserverTarget = null;
     return;
   }
 
-  const rect = sidebar.getBoundingClientRect();
-  const collapsed = rect.width < 80 || sidebar.offsetParent === null;
+  activeHost.removeAttribute('data-ai-companion-hidden');
+  if (activeHost.parentElement !== sidebar) {
+    sidebar.appendChild(activeHost);
+  }
+
+  const measurementTarget =
+    (sidebar.closest('[data-testid="left-sidebar"]') as HTMLElement | null) ??
+    (sidebar.closest('nav') as HTMLElement | null) ??
+    sidebar;
+
+  const rect = measurementTarget.getBoundingClientRect();
+  const collapsed =
+    rect.width < 80 ||
+    measurementTarget.offsetParent === null ||
+    measurementTarget.getAttribute('data-state') === 'collapsed' ||
+    measurementTarget.classList.contains('collapsed');
 
   if (collapsed) {
     activeHost.setAttribute('data-ai-companion-collapsed', 'true');
-    if (fallbackContainer && activeHost.parentElement !== fallbackContainer) {
-      fallbackContainer.appendChild(activeHost);
-    }
   } else {
     activeHost.removeAttribute('data-ai-companion-collapsed');
-    if (activeHost.parentElement !== sidebar) {
-      sidebar.appendChild(activeHost);
-    }
   }
 
   if (!sidebarResizeObserver) {
     sidebarResizeObserver = new ResizeObserver(() => {
-      ensureHostPlacement();
+      window.requestAnimationFrame(() => {
+        ensureHostPlacement();
+      });
     });
   }
 
-  if (observedSidebar !== sidebar) {
-    if (observedSidebar && sidebarResizeObserver) {
-      sidebarResizeObserver.unobserve(observedSidebar);
+  if (resizeObserverTarget !== measurementTarget) {
+    if (resizeObserverTarget && sidebarResizeObserver) {
+      sidebarResizeObserver.unobserve(resizeObserverTarget);
     }
 
-    observedSidebar = sidebar;
-    sidebarResizeObserver.observe(sidebar);
+    resizeObserverTarget = measurementTarget;
+    sidebarResizeObserver.observe(measurementTarget);
   }
 }
 
@@ -165,7 +214,7 @@ async function ensureShadowHost(): Promise<HTMLElement> {
   }
 
   const sidebar = await waitForSidebarContainer();
-  const host = document.createElement('div');
+  const host = document.createElement('li');
   host.id = HOST_ID;
   sidebar.appendChild(host);
   initializeSidebarWatchers(host);
@@ -179,17 +228,34 @@ function mountReact(rootElement: HTMLElement) {
   const shadow = rootElement.attachShadow({ mode: 'open' });
   const style = document.createElement('style');
   style.textContent = `
-    :host { all: initial; display: block; width: 100%; }
-    :host([data-ai-companion-collapsed="true"]) {
-      position: fixed;
-      top: 16px;
-      right: 16px;
-      width: min(20rem, calc(100vw - 32px));
-      max-width: calc(100vw - 32px);
-      z-index: 2147483646;
+    :host {
+      all: initial;
+      display: list-item;
+      width: 100%;
+      color: inherit;
+      font: inherit;
+      list-style: none;
+      pointer-events: auto;
+    }
+    :host([data-ai-companion-hidden="true"]) {
+      display: none !important;
+    }
+    :host([data-ai-companion-collapsed="true"]) .ai-companion-label,
+    :host([data-ai-companion-collapsed="true"]) .ai-companion-subtitle,
+    :host([data-ai-companion-collapsed="true"]) .ai-companion-chevron {
+      display: none !important;
+    }
+    :host([data-ai-companion-collapsed="true"]) .ai-companion-button {
+      justify-content: center;
+      padding: 0.75rem;
+    }
+    :host([data-ai-companion-collapsed="true"]) .ai-companion-panel {
+      display: none !important;
     }
     *, *::before, *::after { box-sizing: border-box; }
-    button { font: inherit; }
+    button { font: inherit; color: inherit; background: none; border: none; cursor: pointer; padding: 0; }
+    a { color: inherit; text-decoration: none; }
+    svg { display: block; }
   `;
   shadow.appendChild(style);
   const globalStyles = document.createElement('link');
@@ -201,9 +267,48 @@ function mountReact(rootElement: HTMLElement) {
   return shadow;
 }
 
-function CompanionOverlay() {
+function CompanionSidebarItem() {
+  const panelId = useId();
+  const [isExpanded, setExpanded] = useState(false);
   const [isModalOpen, setModalOpen] = useState(false);
   const [activeToolbar, setActiveToolbar] = useState<'history' | 'prompts' | 'media'>('history');
+
+  useEffect(() => {
+    const host = document.getElementById(HOST_ID);
+    if (!host) {
+      return;
+    }
+    if (isExpanded) {
+      host.setAttribute('data-ai-companion-open', 'true');
+    } else {
+      host.removeAttribute('data-ai-companion-open');
+    }
+  }, [isExpanded]);
+
+  useEffect(() => {
+    const host = document.getElementById(HOST_ID);
+    if (!host) {
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      if (host.getAttribute('data-ai-companion-collapsed') === 'true') {
+        setExpanded(false);
+      }
+    });
+    observer.observe(host, { attributes: true, attributeFilter: ['data-ai-companion-collapsed'] });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      const host = document.getElementById(HOST_ID);
+      if (host) {
+        host.removeAttribute('data-ai-companion-open');
+      }
+    };
+  }, []);
 
   const toolbarLabel = useMemo(() => {
     switch (activeToolbar) {
@@ -217,72 +322,125 @@ function CompanionOverlay() {
     }
   }, [activeToolbar]);
 
+  const chevronClasses = `ai-companion-chevron h-4 w-4 text-slate-400 transition-transform duration-200 ${
+    isExpanded ? 'rotate-180 text-slate-200' : ''
+  }`;
+  const panelClasses = `ai-companion-panel ${
+    isExpanded
+      ? 'mt-2 space-y-4 rounded-xl border border-white/10 bg-white/5 p-4 text-slate-100 shadow-lg backdrop-blur-sm'
+      : 'hidden'
+  }`;
+
   return (
-    <div className="pointer-events-auto w-full rounded-xl border border-slate-800 bg-slate-950/95 p-4 text-slate-100 shadow-xl">
-      <header className="mb-4 flex items-center justify-between">
-        <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-400">AI Companion</p>
-          <h2 className="text-base font-semibold">{toolbarLabel}</h2>
-        </div>
-        <button
-          className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
-          onClick={() => setModalOpen(true)}
-          type="button"
-        >
-          Patterns
-        </button>
-      </header>
-      <Tabs defaultValue="history" onChange={(value) => setActiveToolbar(value as typeof activeToolbar)}>
-        <TabList className="mb-2 flex gap-2">
-          <Tab value="history">History</Tab>
-          <Tab value="prompts">Prompts</Tab>
-          <Tab value="media">Media</Tab>
-        </TabList>
-        <TabPanels className="rounded-md border border-slate-800 bg-slate-900/60 p-3 text-sm text-slate-200">
-          <TabPanel value="history">
-            <p>
-              Save and pin chats directly from the conversation view. Table presets created here sync with the dashboard.
-            </p>
-          </TabPanel>
-          <TabPanel value="prompts">
-            <p>
-              Build prompt chains inline, attach them to GPT folders, and reuse them across popup and options surfaces.
-            </p>
-          </TabPanel>
-          <TabPanel value="media">
-            <p>
-              Voice overlays reuse the shared modal + overlay primitives to ensure consistent focus management and styling.
-            </p>
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-      <Modal labelledBy="overlay-modal-heading" onClose={() => setModalOpen(false)} open={isModalOpen}>
-        <ModalHeader>
-          <h3 id="overlay-modal-heading" className="text-lg font-semibold text-slate-100">
-            Shared component library
-          </h3>
-          <p className="text-sm text-slate-300">
-            Modals, tabs, and overlays are rendered within a shadow root so styles do not collide with ChatGPT.
-          </p>
-        </ModalHeader>
-        <ModalBody>
-          <ul className="list-disc space-y-2 pl-6 text-sm text-slate-200">
-            <li>Keyboard shortcuts remain functional thanks to consistent escape handling.</li>
-            <li>All surfaces respect RTL layouts and localized labels from the shared i18n bundle.</li>
-            <li>Zustand domain stores hydrate content, popup, and options entries without prop drilling.</li>
-          </ul>
-        </ModalBody>
-        <ModalFooter>
+    <>
+      <button
+        aria-controls={panelId}
+        aria-expanded={isExpanded}
+        aria-label="AI Companion"
+        className="ai-companion-button group flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-[13px] font-medium text-slate-200 transition-colors hover:bg-white/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+        onClick={() => setExpanded((previous) => !previous)}
+        type="button"
+      >
+        <span className="ai-companion-icon flex h-7 w-7 items-center justify-center rounded-md bg-gradient-to-br from-emerald-400 via-emerald-500 to-emerald-600 text-[11px] font-semibold uppercase tracking-wide text-emerald-950 shadow-sm">
+          AI
+        </span>
+        <span className="ai-companion-label flex-1">
+          <span className="block text-sm font-semibold leading-tight text-slate-100">AI Companion</span>
+          <span className="ai-companion-subtitle mt-0.5 block text-xs font-normal text-slate-400">
+            Quick tools & prompts
+          </span>
+        </span>
+        <svg aria-hidden className={chevronClasses} fill="none" viewBox="0 0 20 20">
+          <path
+            d="M6 8l4 4 4-4"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+          />
+        </svg>
+      </button>
+      <div aria-hidden={!isExpanded} className={panelClasses} id={panelId}>
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-400">AI Companion</p>
+            <h2 className="text-base font-semibold text-slate-50">{toolbarLabel}</h2>
+          </div>
           <button
-            className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
-            onClick={() => setModalOpen(false)}
+            className="rounded-md border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-100 transition-colors hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+            onClick={() => setModalOpen(true)}
             type="button"
           >
-            Close
+            Patterns
           </button>
-        </ModalFooter>
-      </Modal>
-    </div>
+        </header>
+        <Tabs defaultValue="history" onChange={(value) => setActiveToolbar(value as typeof activeToolbar)}>
+          <TabList className="ai-companion-tabs mb-3 flex gap-2 rounded-lg bg-white/5 p-1">
+            <Tab
+              className="flex-1 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition-colors aria-selected:bg-emerald-500 aria-selected:text-emerald-950 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+              value="history"
+            >
+              History
+            </Tab>
+            <Tab
+              className="flex-1 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition-colors aria-selected:bg-emerald-500 aria-selected:text-emerald-950 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+              value="prompts"
+            >
+              Prompts
+            </Tab>
+            <Tab
+              className="flex-1 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition-colors aria-selected:bg-emerald-500 aria-selected:text-emerald-950 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+              value="media"
+            >
+              Media
+            </Tab>
+          </TabList>
+          <TabPanels className="ai-companion-tab-panels space-y-3 rounded-lg border border-white/10 bg-slate-900/40 p-3 text-sm text-slate-200 shadow-inner">
+            <TabPanel value="history">
+              <p>
+                Save and pin chats directly from the conversation view. Table presets created here sync with the dashboard.
+              </p>
+            </TabPanel>
+            <TabPanel value="prompts">
+              <p>
+                Build prompt chains inline, attach them to GPT folders, and reuse them across popup and options surfaces.
+              </p>
+            </TabPanel>
+            <TabPanel value="media">
+              <p>
+                Voice overlays reuse the shared modal + overlay primitives to ensure consistent focus management and styling.
+              </p>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+        <Modal labelledBy="overlay-modal-heading" onClose={() => setModalOpen(false)} open={isModalOpen}>
+          <ModalHeader>
+            <h3 id="overlay-modal-heading" className="text-lg font-semibold text-slate-100">
+              Shared component library
+            </h3>
+            <p className="text-sm text-slate-300">
+              Modals, tabs, and overlays are rendered within a shadow root so styles do not collide with ChatGPT.
+            </p>
+          </ModalHeader>
+          <ModalBody>
+            <ul className="list-disc space-y-2 pl-6 text-sm text-slate-200">
+              <li>Keyboard shortcuts remain functional thanks to consistent escape handling.</li>
+              <li>All surfaces respect RTL layouts and localized labels from the shared i18n bundle.</li>
+              <li>Zustand domain stores hydrate content, popup, and options entries without prop drilling.</li>
+            </ul>
+          </ModalBody>
+          <ModalFooter>
+            <button
+              className="rounded-md border border-white/10 bg-white/10 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-100 transition-colors hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+              onClick={() => setModalOpen(false)}
+              type="button"
+            >
+              Close
+            </button>
+          </ModalFooter>
+        </Modal>
+      </div>
+    </>
   );
 }
 
@@ -296,7 +454,7 @@ function init() {
     const root = createRoot(container);
     root.render(
       <StrictMode>
-        <CompanionOverlay />
+        <CompanionSidebarItem />
       </StrictMode>
     );
   });


### PR DESCRIPTION
## Summary
- ensure the companion shadow host is always appended to the primary sidebar list and observe layout changes for reinsertion
- restyle the injected shadow content to mirror ChatGPT’s sidebar card layout and handle the collapsed rail with CSS
- replace the floating overlay with a list-item based companion entry that expands in place while preserving modal tools

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e106a0c3cc8333b738106ac89fa7eb