### PR TITLE
Fix companion sidebar markup and modal structure

### DIFF
--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -1,4 +1,5 @@
-import React, { StrictMode, useEffect, useId, useMemo, useState } from 'react';
+import React, { StrictMode, useId, useMemo, useState } from 'react';
+import type { ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useTranslation } from 'react-i18next';
 
@@ -6,6 +7,73 @@ import { ensureShadowHost } from './sidebar-host';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/ui/components/Modal';
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@/ui/components/Tabs';
 import globalStylesUrl from '@/styles/global.css?url';
+
+function ensureShadowRoot(host: HTMLElement): ShadowRoot {
+  const shadow = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
+
+  if (!shadow.querySelector('link[data-ai-companion="global-styles"]')) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = globalStylesUrl;
+    link.setAttribute('data-ai-companion', 'global-styles');
+    shadow.appendChild(link);
+  }
+
+  if (!shadow.querySelector('style[data-ai-companion="reset"]')) {
+    const style = document.createElement('style');
+    style.setAttribute('data-ai-companion', 'reset');
+    style.textContent = `
+:host {
+  all: initial;
+  display: contents;
+}
+:host *,
+:host *::before,
+:host *::after {
+  box-sizing: border-box;
+}
+`;
+    shadow.appendChild(style);
+  }
+
+  return shadow;
+}
+
+function mountReact(host: HTMLElement): HTMLDivElement {
+  const shadow = ensureShadowRoot(host);
+  host.textContent = '';
+
+  let container = shadow.querySelector<HTMLDivElement>('div[data-ai-companion="root"]');
+  if (!container) {
+    container = document.createElement('div');
+    container.setAttribute('data-ai-companion', 'root');
+    container.className = 'ai-companion-root';
+    shadow.appendChild(container);
+  }
+
+  return container;
+}
+
+const toolbarOrder = ['history', 'prompts', 'media'] as const;
+type ToolbarKey = (typeof toolbarOrder)[number];
+
+function CompanionSidebarItem(): ReactElement {
+  const { t } = useTranslation();
+  const modalHeadingId = useId();
+  const [activeToolbar, setActiveToolbar] = useState<ToolbarKey>('history');
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const toolbarLabel = useMemo(
+    () => t(`content.sidebar.toolbars.${activeToolbar}` as const),
+    [activeToolbar, t]
+  );
+
+  const modalPoints = useMemo(() => {
+    const points = t('content.sidebar.modal.points', { returnObjects: true });
+    return Array.isArray(points) ? (points as string[]) : [];
+  }, [t]);
+
+  return (
     <div className="pointer-events-auto w-full rounded-xl border border-slate-800 bg-slate-950/95 p-4 text-slate-100 shadow-xl">
       <header className="mb-4 flex items-center justify-between">
         <div>
@@ -23,27 +91,32 @@ import globalStylesUrl from '@/styles/global.css?url';
           {t('content.sidebar.patternButton')}
         </button>
       </header>
-      <Tabs defaultValue="history" onChange={(value) => setActiveToolbar(value as typeof activeToolbar)}>
+      <Tabs
+        defaultValue={toolbarOrder[0]}
+        onChange={(value) => {
+          if (toolbarOrder.includes(value as ToolbarKey)) {
+            setActiveToolbar(value as ToolbarKey);
+          }
+        }}
+      >
         <TabList className="mb-2 flex gap-2">
-          <Tab value="history">{t('content.sidebar.tabs.history')}</Tab>
-          <Tab value="prompts">{t('content.sidebar.tabs.prompts')}</Tab>
-          <Tab value="media">{t('content.sidebar.tabs.media')}</Tab>
+          {toolbarOrder.map((key) => (
+            <Tab key={key} value={key}>
+              {t(`content.sidebar.tabs.${key}`)}
+            </Tab>
+          ))}
         </TabList>
         <TabPanels className="rounded-md border border-slate-800 bg-slate-900/60 p-3 text-sm text-slate-200">
-          <TabPanel value="history">
-            <p>{t('content.sidebar.tabDescriptions.history')}</p>
-          </TabPanel>
-          <TabPanel value="prompts">
-            <p>{t('content.sidebar.tabDescriptions.prompts')}</p>
-          </TabPanel>
-          <TabPanel value="media">
-            <p>{t('content.sidebar.tabDescriptions.media')}</p>
-          </TabPanel>
+          {toolbarOrder.map((key) => (
+            <TabPanel key={key} value={key}>
+              <p>{t(`content.sidebar.tabDescriptions.${key}`)}</p>
+            </TabPanel>
+          ))}
         </TabPanels>
       </Tabs>
-      <Modal labelledBy="overlay-modal-heading" onClose={() => setModalOpen(false)} open={isModalOpen}>
-        <ModalHeader>
-          <h3 id="overlay-modal-heading" className="text-lg font-semibold text-slate-100">
+      <Modal labelledBy={modalHeadingId} onClose={() => setModalOpen(false)} open={isModalOpen}>
+        <ModalHeader className="space-y-2">
+          <h3 id={modalHeadingId} className="text-lg font-semibold text-slate-100">
             {t('content.sidebar.modal.title')}
           </h3>
           <p className="text-sm text-slate-300">{t('content.sidebar.modal.description')}</p>
@@ -51,7 +124,7 @@ import globalStylesUrl from '@/styles/global.css?url';
         <ModalBody>
           <ul className="list-disc space-y-2 pl-6 text-sm text-slate-200">
             {modalPoints.map((item, index) => (
-              <li key={index}>{item}</li>
+              <li key={`${item}-${index}`}>{item}</li>
             ))}
           </ul>
         </ModalBody>
@@ -64,84 +137,15 @@ import globalStylesUrl from '@/styles/global.css?url';
           >
             {t('content.sidebar.modal.close')}
           </button>
-        </header>
-        <Tabs defaultValue="history" onChange={(value) => setActiveToolbar(value as typeof activeToolbar)}>
-          <TabList className="ai-companion-tabs mb-3 flex gap-2 rounded-lg bg-white/5 p-1">
-            <Tab
-              className="flex-1 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition-colors aria-selected:bg-emerald-500 aria-selected:text-emerald-950 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
-              value="history"
-            >
-              History
-            </Tab>
-            <Tab
-              className="flex-1 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition-colors aria-selected:bg-emerald-500 aria-selected:text-emerald-950 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
-              value="prompts"
-            >
-              Prompts
-            </Tab>
-            <Tab
-              className="flex-1 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition-colors aria-selected:bg-emerald-500 aria-selected:text-emerald-950 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
-              value="media"
-            >
-              Media
-            </Tab>
-          </TabList>
-          <TabPanels className="ai-companion-tab-panels space-y-3 rounded-lg border border-white/10 bg-slate-900/40 p-3 text-sm text-slate-200 shadow-inner">
-            <TabPanel value="history">
-              <p>
-                Save and pin chats directly from the conversation view. Table presets created here sync with the dashboard.
-              </p>
-            </TabPanel>
-            <TabPanel value="prompts">
-              <p>
-                Build prompt chains inline, attach them to GPT folders, and reuse them across popup and options surfaces.
-              </p>
-            </TabPanel>
-            <TabPanel value="media">
-              <p>
-                Voice overlays reuse the shared modal + overlay primitives to ensure consistent focus management and styling.
-              </p>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-        <Modal labelledBy="overlay-modal-heading" onClose={() => setModalOpen(false)} open={isModalOpen}>
-          <ModalHeader>
-            <h3 id="overlay-modal-heading" className="text-lg font-semibold text-slate-100">
-              Shared component library
-            </h3>
-            <p className="text-sm text-slate-300">
-              Modals, tabs, and overlays are rendered within a shadow root so styles do not collide with ChatGPT.
-            </p>
-          </ModalHeader>
-          <ModalBody>
-            <ul className="list-disc space-y-2 pl-6 text-sm text-slate-200">
-              <li>Keyboard shortcuts remain functional thanks to consistent escape handling.</li>
-              <li>All surfaces respect RTL layouts and localized labels from the shared i18n bundle.</li>
-              <li>Zustand domain stores hydrate content, popup, and options entries without prop drilling.</li>
-            </ul>
-          </ModalBody>
-          <ModalFooter>
-            <button
-              className="rounded-md border border-white/10 bg-white/10 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-100 transition-colors hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
-              onClick={() => setModalOpen(false)}
-              type="button"
-            >
-              Close
-            </button>
-          </ModalFooter>
-        </Modal>
-      </div>
-    </>
+        </ModalFooter>
+      </Modal>
+    </div>
   );
 }
 
 function init() {
   ensureShadowHost().then((host) => {
-    const shadow = mountReact(host);
-    const container = shadow.querySelector('div:last-of-type') as HTMLDivElement | null;
-    if (!container) {
-      throw new Error('Failed to initialize companion overlay container');
-    }
+    const container = mountReact(host);
     const root = createRoot(container);
     root.render(
       <StrictMode>


### PR DESCRIPTION
## Summary
- rebuild the content sidebar React tree to restore valid modal and tab markup
- mount the sidebar inside a managed shadow root and attach global styles safely
- streamline toolbar tab rendering using localization keys for labels and descriptions

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e111d76880833398ca7afd4462d652