### PR TITLE
Align popup cards with stored bookmarks and activity

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ This living document combines the architectural snapshot, delivery status, and p
 - Move MiniSearch indexing into a worker or incremental task so large datasets do not block the UI on rebuild.
 - ✅ Promote the TXT/JSON export flow beyond manual scheduling by integrating the background handler and download APIs; downloads now trigger automatically from scheduled jobs with export status surfaced in the dashboard.
 - ✅ Flesh out job retry/backoff handling and surface status in the dashboard with exponential backoff and a jobs overview widget in the options surface.
-- Align feature toggles and placeholder cards with actual data (bookmarks/pinned/activity).
+- ✅ Align feature toggles and placeholder cards with actual data (bookmarks/pinned/activity).
 
 ### Future themes (Phases 4–8)
 Document outstanding design/ADR links before development starts. Create new ADRs only when implementation work is committed so contributors can trace scope without guessing.

--- a/src/core/storage/db.ts
+++ b/src/core/storage/db.ts
@@ -113,6 +113,19 @@ export class CompanionDatabase extends Dexie {
       jobs: 'id, status, runAt',
       metadata: 'key'
     });
+
+    this.version(5).stores({
+      conversations: 'id, updatedAt, folderId, pinned, archived',
+      messages: 'id, [conversationId+createdAt], conversationId, createdAt',
+      gpts: 'id, folderId, updatedAt',
+      prompts: 'id, folderId, gptId, updatedAt',
+      promptChains: 'id, updatedAt',
+      folders: 'id, parentId, kind',
+      bookmarks: 'id, [conversationId+messageId], conversationId, createdAt',
+      settings: 'id',
+      jobs: 'id, status, runAt, updatedAt',
+      metadata: 'key'
+    });
   }
 }
 

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -7,3 +7,4 @@ export * from './promptChains';
 export * from './settings';
 export * from './syncBridge';
 export * from './service';
+export * from './insights';

--- a/src/core/storage/insights.ts
+++ b/src/core/storage/insights.ts
@@ -1,0 +1,138 @@
+import { db } from './db';
+import {
+  extendConversationsWithCounts,
+  getConversationOverviewById
+} from './conversations';
+import type { BookmarkRecord, JobStatus } from '@/core/models';
+import type { ConversationOverview } from './conversations';
+
+function sanitizePreview(content: string, maxLength = 140) {
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+export interface BookmarkSummary {
+  id: string;
+  conversationId: string;
+  conversationTitle: string;
+  conversationPinned: boolean;
+  createdAt: string;
+  messageId?: string | null;
+  messagePreview?: string;
+  note?: string;
+}
+
+export interface JobActivitySnapshot {
+  id: string;
+  jobId: string;
+  type: string;
+  status: JobStatus;
+  runAt: string;
+  updatedAt: string;
+  completedAt?: string;
+  lastRunAt?: string;
+  lastError?: string;
+  attempts: number;
+  maxAttempts: number;
+}
+
+export type ActivityItem =
+  | { kind: 'conversation'; id: string; timestamp: string; conversation: ConversationOverview }
+  | { kind: 'bookmark'; id: string; timestamp: string; bookmark: BookmarkSummary }
+  | { kind: 'job'; id: string; timestamp: string; job: JobActivitySnapshot };
+
+async function toBookmarkSummary(bookmark: BookmarkRecord): Promise<BookmarkSummary | null> {
+  const conversation = await getConversationOverviewById(bookmark.conversationId);
+  if (!conversation) {
+    return null;
+  }
+
+  let messagePreview: string | undefined;
+  if (bookmark.messageId) {
+    const message = await db.messages.get(bookmark.messageId);
+    if (message) {
+      messagePreview = sanitizePreview(message.content);
+    }
+  }
+
+  return {
+    id: bookmark.id,
+    conversationId: bookmark.conversationId,
+    conversationTitle: conversation.title,
+    conversationPinned: conversation.pinned,
+    createdAt: bookmark.createdAt,
+    messageId: bookmark.messageId,
+    messagePreview,
+    note: bookmark.note
+  } satisfies BookmarkSummary;
+}
+
+export async function getRecentBookmarks(limit = 10): Promise<BookmarkSummary[]> {
+  const bookmarks = await db.bookmarks.orderBy('createdAt').reverse().limit(limit).toArray();
+  const summaries = await Promise.all(bookmarks.map((bookmark) => toBookmarkSummary(bookmark)));
+  return summaries.filter((bookmark): bookmark is BookmarkSummary => Boolean(bookmark));
+}
+
+export async function getRecentActivity(limit = 10): Promise<ActivityItem[]> {
+  const [conversations, bookmarks, jobs] = await Promise.all([
+    db.conversations.orderBy('updatedAt').reverse().limit(limit).toArray(),
+    db.bookmarks.orderBy('createdAt').reverse().limit(limit).toArray(),
+    db.jobs.orderBy('updatedAt').reverse().limit(limit).toArray()
+  ]);
+
+  const [conversationItems, bookmarkItems] = await Promise.all([
+    extendConversationsWithCounts(conversations),
+    Promise.all(bookmarks.map((bookmark) => toBookmarkSummary(bookmark)))
+  ]);
+
+  const activity: ActivityItem[] = [];
+
+  for (const conversation of conversationItems) {
+    activity.push({
+      kind: 'conversation',
+      id: `conversation:${conversation.id}`,
+      timestamp: conversation.updatedAt,
+      conversation
+    });
+  }
+
+  for (const bookmark of bookmarkItems) {
+    if (!bookmark) {
+      continue;
+    }
+    activity.push({
+      kind: 'bookmark',
+      id: `bookmark:${bookmark.id}`,
+      timestamp: bookmark.createdAt,
+      bookmark
+    });
+  }
+
+  for (const job of jobs) {
+    activity.push({
+      kind: 'job',
+      id: `job:${job.id}`,
+      timestamp: job.updatedAt ?? job.createdAt,
+      job: {
+        id: `job:${job.id}`,
+        jobId: job.id,
+        type: job.type,
+        status: job.status,
+        runAt: job.runAt,
+        updatedAt: job.updatedAt,
+        completedAt: job.completedAt,
+        lastRunAt: job.lastRunAt,
+        lastError: job.lastError,
+        attempts: job.attempts,
+        maxAttempts: job.maxAttempts
+      }
+    });
+  }
+
+  return activity
+    .sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0))
+    .slice(0, limit);
+}

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,7 +1,11 @@
 ﻿import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { ActivityItem, BookmarkSummary } from '@/core/storage';
 import { toggleBookmark, togglePinned } from '@/core/storage';
+import { usePinnedConversations } from '@/shared/hooks/usePinnedConversations';
+import { useRecentActivity } from '@/shared/hooks/useRecentActivity';
+import { useRecentBookmarks } from '@/shared/hooks/useRecentBookmarks';
 import { useRecentConversations } from '@/shared/hooks/useRecentConversations';
 import { initI18n, setLanguage } from '@/shared/i18n';
 import { useSettingsStore } from '@/shared/state/settingsStore';
@@ -23,10 +27,71 @@ function openConversationTab(conversationId: string) {
   });
 }
 
+function formatDateTime(value: string) {
+  return new Date(value).toLocaleString();
+}
+
+function normalizeTitle(title: string | undefined | null, fallback: string) {
+  if (typeof title !== 'string') {
+    return fallback;
+  }
+  const trimmed = title.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function formatBookmarkPreview(bookmark: BookmarkSummary, fallback: string) {
+  if (bookmark.messagePreview) {
+    return bookmark.messagePreview;
+  }
+  return fallback;
+}
+
+function openDashboard() {
+  if (chrome.runtime?.openOptionsPage) {
+    chrome.runtime.openOptionsPage(() => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        console.error('[ai-companion] failed to open options page', lastError);
+      }
+    });
+    return;
+  }
+
+  const url = chrome.runtime?.getURL?.('options.html');
+  if (url) {
+    chrome.tabs.create({ url }).catch((error) => {
+      console.error('[ai-companion] failed to open dashboard tab', error);
+    });
+  }
+}
+
+function getActivityAccent(item: ActivityItem) {
+  if (item.kind === 'job') {
+    switch (item.job.status) {
+      case 'failed':
+        return 'bg-rose-400';
+      case 'running':
+        return 'bg-sky-400';
+      case 'completed':
+        return 'bg-emerald-400';
+      case 'pending':
+      default:
+        return 'bg-amber-400';
+    }
+  }
+  if (item.kind === 'bookmark') {
+    return 'bg-amber-400';
+  }
+  return 'bg-emerald-400';
+}
+
 export function Popup() {
   const { t, i18n } = useTranslation();
   const { language, direction, setLanguage: setStoreLanguage, toggleDirection } = useSettingsStore();
   const conversations = useRecentConversations(5);
+  const pinnedConversations = usePinnedConversations(4);
+  const recentBookmarks = useRecentBookmarks(4);
+  const recentActivity = useRecentActivity(6);
   const [authStatus, setAuthStatus] = useState<{ authenticated: boolean; premium: boolean } | null>(null);
 
   const handlePinClick = async (conversationId: string) => {
@@ -53,6 +118,36 @@ export function Popup() {
     }
     document.documentElement.dir = direction;
   }, [language, direction, i18n]);
+
+  const untitledConversationLabel = t('popup.untitledConversation') || 'Untitled conversation';
+  const bookmarkFallbackPreview = t('popup.bookmarkConversationOnly') || 'Conversation bookmark';
+  const pinnedBadgeLabel = t('popup.pinnedBadge') || 'Pinned';
+  const jobStatusLabels = {
+    pending: t('popup.activityJobStatus.pending'),
+    running: t('popup.activityJobStatus.running'),
+    completed: t('popup.activityJobStatus.completed'),
+    failed: t('popup.activityJobStatus.failed')
+  } as const;
+  const jobTypeLabels: Record<string, string> = {
+    export: t('popup.activityJobType.export') || 'Export'
+  };
+  const resolveJobTypeLabel = (type: string) => {
+    if (jobTypeLabels[type]) {
+      return jobTypeLabels[type];
+    }
+    if (!type) {
+      return 'Job';
+    }
+    return type.charAt(0).toUpperCase() + type.slice(1);
+  };
+  const resolveJobStatusLabel = (status: keyof typeof jobStatusLabels) =>
+    jobStatusLabels[status] ?? status;
+  const noBookmarksLabel = t('popup.noBookmarks') || 'Save bookmarks to see them here.';
+  const noPinnedLabel =
+    t('popup.noPinned') || 'Pin important conversations to keep them handy.';
+  const noActivityLabel =
+    t('popup.noActivity') ||
+    'Recent conversation edits, bookmarks, and exports will show up here.';
 
   return (
     <div className="w-96 space-y-4 p-4" dir={direction}>
@@ -176,24 +271,257 @@ export function Popup() {
 
       <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">{t('popup.bookmarks')}</h2>
-        <p className="mt-2 text-sm text-slate-300">Structured conversation bookmarks arrive soon.</p>
+        {recentBookmarks.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-300">{noBookmarksLabel}</p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {recentBookmarks.map((bookmark) => (
+              <li
+                key={bookmark.id}
+                className="rounded-md border border-slate-800 bg-slate-900/80 p-3 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium text-slate-100">
+                        {normalizeTitle(bookmark.conversationTitle, untitledConversationLabel)}
+                      </p>
+                      {bookmark.conversationPinned ? (
+                        <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                          {pinnedBadgeLabel}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="text-xs text-slate-400">
+                      {t('popup.bookmarkSaved', {
+                        time: formatDateTime(bookmark.createdAt)
+                      })}
+                    </p>
+                  </div>
+                  <button
+                    className="rounded-md border border-slate-700 bg-slate-800 px-3 py-1 text-[11px] font-semibold text-slate-200"
+                    onClick={() => openConversationTab(bookmark.conversationId)}
+                  >
+                    {t('popup.openConversation')}
+                  </button>
+                </div>
+                <div className="mt-2 space-y-1 text-xs text-slate-300">
+                  <p>{formatBookmarkPreview(bookmark, bookmarkFallbackPreview)}</p>
+                  {bookmark.note ? (
+                    <p className="text-[11px] text-slate-400">
+                      {t('popup.bookmarkNote', {
+                        note: bookmark.note
+                      })}
+                    </p>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
 
       <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">{t('popup.pinnedChats')}</h2>
-        <p className="mt-2 text-sm text-slate-300">Pin priority threads for quick access.</p>
+        {pinnedConversations.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-300">{noPinnedLabel}</p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {pinnedConversations.map((conversation) => (
+              <li
+                key={conversation.id}
+                className="rounded-md border border-slate-800 bg-slate-900/80 p-3 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium text-slate-100">
+                      {normalizeTitle(conversation.title, untitledConversationLabel)}
+                    </p>
+                    <p className="text-xs text-slate-400">{formatDateTime(conversation.updatedAt)}</p>
+                  </div>
+                  <button
+                    className="rounded-md border border-slate-700 bg-slate-800 px-3 py-1 text-[11px] font-semibold text-slate-200"
+                    onClick={() => openConversationTab(conversation.id)}
+                  >
+                    {t('popup.openConversation')}
+                  </button>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-slate-400">
+                  <span>
+                    {t('popup.messages')}: {formatNumber(conversation.messageCount)}
+                  </span>
+                  <span>
+                    {t('popup.words')}: {formatNumber(conversation.wordCount)}
+                  </span>
+                  <span>
+                    {t('popup.characters')}: {formatNumber(conversation.charCount)}
+                  </span>
+                  <span>
+                    {(t('popup.bookmarkTotal') || 'Bookmarks')}: {formatNumber(conversation.bookmarkCount)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
 
       <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-3">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <div>
             <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">{t('popup.recentActivity')}</h2>
-            <p className="mt-1 text-xs text-slate-400">Recent chats, exports, and downloads will appear here.</p>
+            <p className="mt-1 text-xs text-slate-400">
+              {t('popup.recentActivityDescription') ||
+                'Latest conversations, bookmarks, and exports at a glance.'}
+            </p>
           </div>
-          <button className="rounded-md bg-emerald-500 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-sm">
+          <button
+            className="rounded-md bg-emerald-500 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-sm"
+            onClick={() => openDashboard()}
+          >
             {t('popup.openDashboard')}
           </button>
         </div>
+        {recentActivity.length === 0 ? (
+          <p className="mt-3 text-sm text-slate-300">{noActivityLabel}</p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {recentActivity.map((item) => {
+              let title: string = '';
+              let subtitle: string | null = null;
+              let attemptsLabel: string | null = null;
+              let action: { label: string; handler: () => void } | null = null;
+
+              if (item.kind === 'conversation') {
+                const conversationTitle = normalizeTitle(
+                  item.conversation.title,
+                  untitledConversationLabel
+                );
+                title =
+                  t('popup.activityConversation', {
+                    title: conversationTitle
+                  }) ?? `${conversationTitle} updated`;
+                const metrics = [
+                  t('popup.activityConversationMetrics', {
+                    messages: formatNumber(item.conversation.messageCount),
+                    words: formatNumber(item.conversation.wordCount)
+                  })
+                ];
+                if (item.conversation.bookmarkCount > 0) {
+                  metrics.push(
+                    t('popup.activityConversationBookmarks', {
+                      formattedCount: formatNumber(item.conversation.bookmarkCount)
+                    })
+                  );
+                }
+                subtitle = metrics.filter(Boolean).join(' • ');
+                action = {
+                  label: t('popup.openConversation'),
+                  handler: () => openConversationTab(item.conversation.id)
+                };
+              } else if (item.kind === 'bookmark') {
+                const conversationTitle = normalizeTitle(
+                  item.bookmark.conversationTitle,
+                  untitledConversationLabel
+                );
+                title =
+                  t('popup.activityBookmark', {
+                    title: conversationTitle
+                  }) ?? `Bookmark saved in ${conversationTitle}`;
+                const subtitleParts = [
+                  formatBookmarkPreview(item.bookmark, bookmarkFallbackPreview)
+                ];
+                if (item.bookmark.note) {
+                  subtitleParts.push(
+                    t('popup.bookmarkNote', {
+                      note: item.bookmark.note
+                    })
+                  );
+                }
+                subtitle = subtitleParts.filter(Boolean).join(' • ');
+                action = {
+                  label: t('popup.openConversation'),
+                  handler: () => openConversationTab(item.bookmark.conversationId)
+                };
+              } else {
+                const typeLabel = resolveJobTypeLabel(item.job.type);
+                const statusLabel = resolveJobStatusLabel(item.job.status);
+                title =
+                  t('popup.activityJob', {
+                    type: typeLabel,
+                    status: statusLabel
+                  }) ?? `${typeLabel} job ${statusLabel}`;
+
+                if (item.job.status === 'failed') {
+                  subtitle = item.job.lastError
+                    ? t('popup.activityJobFailedWithError', {
+                        error: item.job.lastError
+                      })
+                    : t('popup.activityJobFailed', {
+                        attempts: item.job.attempts
+                      });
+                } else if (item.job.status === 'completed') {
+                  subtitle = t('popup.activityJobCompleted', {
+                    time: formatDateTime(item.job.completedAt ?? item.job.updatedAt)
+                  });
+                } else if (item.job.status === 'running') {
+                  subtitle = t('popup.activityJobRunning', {
+                    time: formatDateTime(item.job.lastRunAt ?? item.job.updatedAt)
+                  });
+                } else {
+                  subtitle = t('popup.activityJobScheduled', {
+                    time: formatDateTime(item.job.runAt)
+                  });
+                }
+
+                if (item.job.attempts > 0) {
+                  attemptsLabel = t('popup.activityJobAttempts', {
+                    attempts: item.job.attempts,
+                    max: item.job.maxAttempts
+                  });
+                }
+
+                action = {
+                  label: t('popup.openDashboard'),
+                  handler: () => openDashboard()
+                };
+              }
+
+              const accentClass = getActivityAccent(item);
+
+              return (
+                <li
+                  key={item.id}
+                  className="rounded-md border border-slate-800 bg-slate-900/80 p-3 shadow-sm"
+                >
+                  <div className="flex items-start gap-3">
+                    <span className={`mt-1 h-2 w-2 rounded-full ${accentClass}`} aria-hidden />
+                    <div className="flex-1">
+                      <p className="text-xs font-semibold text-slate-100">{title}</p>
+                      {subtitle ? (
+                        <p className="mt-1 text-[11px] text-slate-400">{subtitle}</p>
+                      ) : null}
+                      {attemptsLabel ? (
+                        <p className="mt-1 text-[11px] text-slate-500">{attemptsLabel}</p>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-col items-end gap-1 text-right">
+                      <span className="text-[11px] text-slate-500">{formatDateTime(item.timestamp)}</span>
+                      {action ? (
+                        <button
+                          className="text-[11px] font-semibold text-emerald-400 hover:text-emerald-300"
+                          onClick={action.handler}
+                        >
+                          {action.label}
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </section>
     </div>
   );

--- a/src/shared/hooks/usePinnedConversations.ts
+++ b/src/shared/hooks/usePinnedConversations.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { liveQuery } from 'dexie';
+
+import { getPinnedConversations } from '@/core/storage';
+import type { ConversationOverview } from '@/core/storage';
+
+export function usePinnedConversations(limit = 5) {
+  const [conversations, setConversations] = useState<ConversationOverview[]>([]);
+
+  useEffect(() => {
+    const subscription = liveQuery(() => getPinnedConversations(limit)).subscribe({
+      next: (value) => setConversations(value),
+      error: (error) => console.error('[ai-companion] pinned conversations live query failed', error)
+    });
+
+    return () => subscription.unsubscribe();
+  }, [limit]);
+
+  return conversations;
+}

--- a/src/shared/hooks/useRecentActivity.ts
+++ b/src/shared/hooks/useRecentActivity.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { liveQuery } from 'dexie';
+
+import { getRecentActivity } from '@/core/storage';
+import type { ActivityItem } from '@/core/storage';
+
+export function useRecentActivity(limit = 6) {
+  const [activity, setActivity] = useState<ActivityItem[]>([]);
+
+  useEffect(() => {
+    const subscription = liveQuery(() => getRecentActivity(limit)).subscribe({
+      next: (value) => setActivity(value),
+      error: (error) => console.error('[ai-companion] recent activity live query failed', error)
+    });
+
+    return () => subscription.unsubscribe();
+  }, [limit]);
+
+  return activity;
+}

--- a/src/shared/hooks/useRecentBookmarks.ts
+++ b/src/shared/hooks/useRecentBookmarks.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { liveQuery } from 'dexie';
+
+import { getRecentBookmarks } from '@/core/storage';
+import type { BookmarkSummary } from '@/core/storage';
+
+export function useRecentBookmarks(limit = 5) {
+  const [bookmarks, setBookmarks] = useState<BookmarkSummary[]>([]);
+
+  useEffect(() => {
+    const subscription = liveQuery(() => getRecentBookmarks(limit)).subscribe({
+      next: (value) => setBookmarks(value),
+      error: (error) => console.error('[ai-companion] recent bookmarks live query failed', error)
+    });
+
+    return () => subscription.unsubscribe();
+  }, [limit]);
+
+  return bookmarks;
+}

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -10,6 +10,11 @@
     "openDashboard": "Open dashboard",
     "recentConversations": "Recent conversations",
     "noConversations": "Start chatting to see history here.",
+    "untitledConversation": "Untitled conversation",
+    "bookmarkConversationOnly": "Conversation bookmark",
+    "bookmarkSaved": "Saved {{time}}",
+    "bookmarkNote": "Note: {{note}}",
+    "pinnedBadge": "Pinned",
     "words": "Words",
     "characters": "Characters",
     "messages": "Messages",
@@ -17,7 +22,32 @@
     "unpin": "Unpin",
     "bookmark": "Bookmark",
     "unbookmark": "Remove bookmark",
-    "openConversation": "Open"
+    "openConversation": "Open",
+    "bookmarkTotal": "Bookmarks",
+    "noBookmarks": "Save bookmarks to see them here.",
+    "noPinned": "Pin important conversations to keep them handy.",
+    "noActivity": "Recent conversation edits, bookmarks, and exports will show up here.",
+    "recentActivityDescription": "Latest conversations, bookmarks, and exports at a glance.",
+    "activityConversation": "{{title}} updated",
+    "activityConversationMetrics": "{{messages}} messages · {{words}} words",
+    "activityConversationBookmarks": "{{formattedCount}} bookmarks",
+    "activityBookmark": "Bookmark saved in {{title}}",
+    "activityJob": "{{type}} job {{status}}",
+    "activityJobStatus": {
+      "pending": "Scheduled",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Failed"
+    },
+    "activityJobType": {
+      "export": "Export"
+    },
+    "activityJobFailedWithError": "Failed: {{error}}",
+    "activityJobFailed": "Job failed after {{attempts}} attempts",
+    "activityJobCompleted": "Completed {{time}}",
+    "activityJobRunning": "Running since {{time}}",
+    "activityJobScheduled": "Scheduled for {{time}}",
+    "activityJobAttempts": "{{attempts}} / {{max}} attempts"
   },
   "options": {
     "heading": "AI Companion Dashboard",

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -10,6 +10,11 @@
     "openDashboard": "Open dashboard",
     "recentConversations": "Recente gesprekken",
     "noConversations": "Start een chat om je geschiedenis hier te zien.",
+    "untitledConversation": "Naamloos gesprek",
+    "bookmarkConversationOnly": "Gespreksbladwijzer",
+    "bookmarkSaved": "Opgeslagen {{time}}",
+    "bookmarkNote": "Notitie: {{note}}",
+    "pinnedBadge": "Vastgezet",
     "words": "Woorden",
     "characters": "Karakters",
     "messages": "Berichten",
@@ -17,7 +22,32 @@
     "unpin": "Losmaken",
     "bookmark": "Bladwijzer",
     "unbookmark": "Bladwijzer verwijderen",
-    "openConversation": "Openen"
+    "openConversation": "Openen",
+    "bookmarkTotal": "Bladwijzers",
+    "noBookmarks": "Sla bladwijzers op om ze hier te zien.",
+    "noPinned": "Zet belangrijke gesprekken vast voor snelle toegang.",
+    "noActivity": "Recente gesprekswijzigingen, bladwijzers en exports verschijnen hier.",
+    "recentActivityDescription": "Laatste gesprekken, bladwijzers en exports in één overzicht.",
+    "activityConversation": "{{title}} bijgewerkt",
+    "activityConversationMetrics": "{{messages}} berichten · {{words}} woorden",
+    "activityConversationBookmarks": "{{formattedCount}} bladwijzers",
+    "activityBookmark": "Bladwijzer opgeslagen in {{title}}",
+    "activityJob": "{{type}}-taak {{status}}",
+    "activityJobStatus": {
+      "pending": "Gepland",
+      "running": "Actief",
+      "completed": "Voltooid",
+      "failed": "Mislukt"
+    },
+    "activityJobType": {
+      "export": "Export"
+    },
+    "activityJobFailedWithError": "Mislukt: {{error}}",
+    "activityJobFailed": "Taak mislukt na {{attempts}} pogingen",
+    "activityJobCompleted": "Voltooid {{time}}",
+    "activityJobRunning": "Actief sinds {{time}}",
+    "activityJobScheduled": "Gepland voor {{time}}",
+    "activityJobAttempts": "{{attempts}} / {{max}} pogingen"
   },
   "options": {
     "heading": "AI Companion Dashboard",


### PR DESCRIPTION
## Summary
- add Dexie-backed helpers for bookmark summaries, activity feed items, and pinned conversation lookups
- surface live bookmarks, pinned chats, and recent activity in the popup alongside navigation controls
- localize new popup strings and mark the roadmap backlog item as completed

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11472d3a08333bc97e701f872ae9a