### PR TITLE
feat: offload minisearch indexing to worker

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,7 +33,7 @@ This living document combines the architectural snapshot, delivery status, and p
 | 8 | Quality & growth | 💤 Planned | Telemetry, observability, and localization scorecards remain future work. |
 
 ### Near-term backlog (Phase 3 focus)
-- Move MiniSearch indexing into a worker or incremental task so large datasets do not block the UI on rebuild.
+- ✅ Move MiniSearch indexing into a worker-driven pipeline so large datasets do not block the UI on rebuild.
 - ✅ Promote the TXT/JSON export flow beyond manual scheduling by integrating the background handler and download APIs; downloads now trigger automatically from scheduled jobs with export status surfaced in the dashboard.
 - ✅ Flesh out job retry/backoff handling and surface status in the dashboard with exponential backoff and a jobs overview widget in the options surface.
 - ✅ Align feature toggles and placeholder cards with actual data (bookmarks/pinned/activity).

--- a/src/core/services/searchService.ts
+++ b/src/core/services/searchService.ts
@@ -2,13 +2,12 @@ import MiniSearch from 'minisearch';
 import type { MetadataRecord } from '@/core/storage/db';
 import { db } from '@/core/storage/db';
 import type { ConversationRecord, MessageRecord } from '@/core/models';
-
-interface SearchDocument {
-  id: string;
-  text: string;
-  conversationId: string;
-  title?: string;
-}
+import {
+  type SearchDocument,
+  type SearchWorkerRequest,
+  type SearchWorkerResponse,
+  type SearchWorkerSuccessResponse,
+} from '@/core/workers/searchIndexWorker.types';
 
 const searchOptions = {
   fields: ['title', 'text'],
@@ -19,36 +18,164 @@ const searchOptions = {
 const SEARCH_INDEX_METADATA_KEY = 'search:index';
 const SEARCH_INDEX_VERSION = 1;
 
-let miniSearch = createMiniSearch();
+const supportsWorkerEnvironment =
+  typeof window !== 'undefined' && typeof window.Worker !== 'undefined';
+
+let workerAvailable = supportsWorkerEnvironment;
+
+let fallbackMiniSearch: MiniSearch<SearchDocument> | null = workerAvailable
+  ? null
+  : createMiniSearch();
 let indexReady = false;
 let buildPromise: Promise<void> | null = null;
 
-interface SearchIndexMetadataValue {
-  version: number;
-  index: string;
-}
-
-function isSearchIndexMetadata(
-  record: MetadataRecord | undefined
-): record is MetadataRecord<SearchIndexMetadataValue> {
-  if (!record || typeof record.value !== 'object' || record.value === null) {
-    return false;
+let worker: Worker | null = null;
+let requestId = 0;
+const pendingWorkerRequests = new Map<
+  number,
+  {
+    resolve: (response: SearchWorkerSuccessResponse) => void;
+    reject: (error: Error) => void;
   }
+>();
 
-  const value = record.value as Partial<SearchIndexMetadataValue>;
-  return typeof value.version === 'number' && typeof value.index === 'string';
-}
+type WorkerAction = SearchWorkerRequest['action'];
+
+type RequestForAction<TAction extends WorkerAction> = Extract<
+  SearchWorkerRequest,
+  { action: TAction }
+>;
+
+type ResponseForAction<TAction extends WorkerAction> = Extract<
+  SearchWorkerSuccessResponse,
+  { action: TAction }
+>;
 
 function createMiniSearch() {
   return new MiniSearch<SearchDocument>(searchOptions);
 }
 
-async function persistIndex() {
-  const record: MetadataRecord<SearchIndexMetadataValue> = {
+function isWorkerActive() {
+  return workerAvailable;
+}
+
+function disableWorker(error?: unknown) {
+  if (!workerAvailable) {
+    return;
+  }
+
+  workerAvailable = false;
+
+  if (error) {
+    console.warn('searchService: disabling worker, falling back to main-thread indexing', error);
+  }
+
+  if (worker) {
+    worker.terminate();
+    worker = null;
+  }
+
+  if (pendingWorkerRequests.size > 0) {
+    const fallbackError =
+      error instanceof Error ? error : new Error('Search index worker disabled');
+    for (const pending of pendingWorkerRequests.values()) {
+      pending.reject(fallbackError);
+    }
+    pendingWorkerRequests.clear();
+  }
+
+  if (!fallbackMiniSearch) {
+    fallbackMiniSearch = createMiniSearch();
+  }
+}
+
+function ensureWorker(): Worker {
+  if (!isWorkerActive()) {
+    throw new Error('Web Workers are not supported in this environment.');
+  }
+
+  if (!worker) {
+    try {
+      worker = new Worker(new URL('../workers/searchIndex.worker.ts', import.meta.url), {
+        type: 'module',
+      });
+    } catch (error) {
+      disableWorker(error);
+      throw error instanceof Error
+        ? error
+        : new Error('Search index worker could not be initialised.');
+    }
+  }
+
+  worker.onmessage = event => {
+    const response = event.data as SearchWorkerResponse;
+    const pending = pendingWorkerRequests.get(response.id);
+    if (!pending) {
+      return;
+    }
+
+    pendingWorkerRequests.delete(response.id);
+
+    if (response.success) {
+      pending.resolve(response);
+    } else {
+      pending.reject(new Error(response.error));
+    }
+  };
+
+  worker.onerror = event => {
+    const error = new Error(`Search index worker failed: ${event.message}`);
+    disableWorker(error);
+  };
+
+  worker.onmessageerror = () => {
+    const error = new Error('Search index worker failed to deserialize a message.');
+    disableWorker(error);
+  };
+
+  return worker;
+}
+
+async function postToWorker<TAction extends WorkerAction>(
+  action: TAction,
+  payload: RequestForAction<TAction>['payload']
+): Promise<ResponseForAction<TAction>> {
+  const workerInstance = ensureWorker();
+  const id = ++requestId;
+
+  const request = {
+    id,
+    action,
+    // TypeScript cannot infer the discriminated union when assigning dynamically.
+    payload: payload as RequestForAction<WorkerAction>['payload'],
+  } as SearchWorkerRequest;
+
+  const responsePromise = new Promise<ResponseForAction<TAction>>((resolve, reject) => {
+    pendingWorkerRequests.set(id, {
+      resolve: resolve as (response: SearchWorkerSuccessResponse) => void,
+      reject,
+    });
+  });
+
+  try {
+    workerInstance.postMessage(request satisfies SearchWorkerRequest);
+  } catch (error) {
+    pendingWorkerRequests.delete(id);
+    disableWorker(error);
+    throw error instanceof Error
+      ? error
+      : new Error('Search index worker could not receive a request.');
+  }
+
+  return responsePromise;
+}
+
+async function persistIndex(serializedIndex: string) {
+  const record: MetadataRecord<{ version: number; index: string }> = {
     key: SEARCH_INDEX_METADATA_KEY,
     value: {
       version: SEARCH_INDEX_VERSION,
-      index: JSON.stringify(miniSearch),
+      index: serializedIndex,
     },
     updatedAt: new Date().toISOString(),
   };
@@ -56,47 +183,92 @@ async function persistIndex() {
   await db.metadata.put(record);
 }
 
+function isSearchIndexMetadata(
+  record: MetadataRecord | undefined
+): record is MetadataRecord<{ version: number; index: string }> {
+  if (!record || typeof record.value !== 'object' || record.value === null) {
+    return false;
+  }
+
+  const value = record.value as Partial<{ version: number; index: string }>;
+  return typeof value.version === 'number' && typeof value.index === 'string';
+}
+
+async function initializeIndex(serializedIndex?: string | null) {
+  if (isWorkerActive()) {
+    try {
+      await postToWorker('INIT', { serializedIndex: serializedIndex ?? null });
+      return;
+    } catch (error) {
+      disableWorker(error);
+    }
+  }
+
+  if (!serializedIndex) {
+    fallbackMiniSearch = createMiniSearch();
+    return;
+  }
+
+  fallbackMiniSearch = await MiniSearch.loadJSONAsync<SearchDocument>(serializedIndex, searchOptions);
+}
+
 async function restorePersistedIndex(): Promise<boolean> {
   const stored = await db.metadata.get(SEARCH_INDEX_METADATA_KEY);
   if (!isSearchIndexMetadata(stored)) {
+    await initializeIndex();
     return false;
   }
 
   if (stored.value.version !== SEARCH_INDEX_VERSION) {
+    await initializeIndex();
     return false;
   }
 
   try {
-    miniSearch = await MiniSearch.loadJSONAsync<SearchDocument>(stored.value.index, searchOptions);
+    await initializeIndex(stored.value.index);
     return true;
   } catch (error) {
     console.warn('searchService: unable to restore persisted index, rebuilding', error);
-    miniSearch = createMiniSearch();
+    await initializeIndex();
     return false;
   }
 }
 
-async function rebuildIndexFromDatabase() {
+async function loadDocumentsFromDatabase(): Promise<SearchDocument[]> {
   const conversations = await db.conversations.toArray();
   const messages = await db.messages.toArray();
 
-  const documents: SearchDocument[] = [
-    ...conversations.map(c => ({
+  return [
+    ...conversations.map<SearchDocument>(c => ({
       id: `conv:${c.id}`,
       text: c.title,
       title: c.title,
       conversationId: c.id,
     })),
-    ...messages.map(m => ({
+    ...messages.map<SearchDocument>(m => ({
       id: `msg:${m.id}`,
       text: m.content,
       conversationId: m.conversationId,
     })),
   ];
+}
 
-  miniSearch = createMiniSearch();
-  await miniSearch.addAllAsync(documents);
-  await persistIndex();
+async function rebuildIndexFromDatabase() {
+  const documents = await loadDocumentsFromDatabase();
+
+  if (isWorkerActive()) {
+    try {
+      const response = await postToWorker('BUILD_FULL_INDEX', { documents });
+      await persistIndex(response.result.serializedIndex);
+      return;
+    } catch (error) {
+      disableWorker(error);
+    }
+  }
+
+  fallbackMiniSearch = createMiniSearch();
+  await fallbackMiniSearch.addAllAsync(documents);
+  await persistIndex(JSON.stringify(fallbackMiniSearch));
 }
 
 export async function buildSearchIndex() {
@@ -109,13 +281,17 @@ export async function buildSearchIndex() {
         await rebuildIndexFromDatabase();
       }
       indexReady = true;
-    })().catch(error => {
-      indexReady = false;
-      miniSearch = createMiniSearch();
-      throw error;
-    }).finally(() => {
-      buildPromise = null;
-    });
+    })()
+      .catch(error => {
+        indexReady = false;
+        if (!isWorkerActive()) {
+          fallbackMiniSearch = createMiniSearch();
+        }
+        throw error;
+      })
+      .finally(() => {
+        buildPromise = null;
+      });
   }
 
   await buildPromise;
@@ -126,40 +302,67 @@ export async function search(query: string): Promise<string[]> {
     await buildSearchIndex();
   }
 
-  const results = miniSearch.search(query, { prefix: true, fuzzy: 0.2 });
+  if (isWorkerActive()) {
+    try {
+      const response = await postToWorker('SEARCH', { query });
+      return response.result.conversationIds;
+    } catch (error) {
+      disableWorker(error);
+    }
+  }
+
+  if (!fallbackMiniSearch) {
+    return [];
+  }
+
+  const results = fallbackMiniSearch.search(query, { prefix: true, fuzzy: 0.2 });
   const conversationIds = new Set(results.map(r => r.conversationId));
   return Array.from(conversationIds);
 }
 
 export async function upsertIntoIndex(items: Array<ConversationRecord | MessageRecord>) {
-  if (!indexReady) return;
+  if (!indexReady || items.length === 0) return;
 
   const documents: SearchDocument[] = items.map(item => {
-    if ('title' in item) { // ConversationRecord
+    if ('title' in item) {
       return {
         id: `conv:${item.id}`,
         text: item.title,
         title: item.title,
         conversationId: item.id,
-      };
-    } else { // MessageRecord
-      return {
-        id: `msg:${item.id}`,
-        text: item.content,
-        conversationId: item.conversationId,
-      };
+      } satisfies SearchDocument;
     }
+
+    return {
+      id: `msg:${item.id}`,
+      text: item.content,
+      conversationId: item.conversationId,
+    } satisfies SearchDocument;
   });
 
-  for (const doc of documents) {
-    if (miniSearch.has(doc.id)) {
-      miniSearch.replace(doc);
-    } else {
-      miniSearch.add(doc);
+  if (isWorkerActive()) {
+    try {
+      const response = await postToWorker('UPSERT', { documents });
+      await persistIndex(response.result.serializedIndex);
+      return;
+    } catch (error) {
+      disableWorker(error);
     }
   }
 
-  await persistIndex();
+  if (!fallbackMiniSearch) {
+    return;
+  }
+
+  for (const doc of documents) {
+    if (fallbackMiniSearch.has(doc.id)) {
+      fallbackMiniSearch.replace(doc);
+    } else {
+      fallbackMiniSearch.add(doc);
+    }
+  }
+
+  await persistIndex(JSON.stringify(fallbackMiniSearch));
 }
 
 export async function removeFromIndex(ids: string[]) {
@@ -170,13 +373,28 @@ export async function removeFromIndex(ids: string[]) {
     .anyOf(ids)
     .primaryKeys();
 
-  for (const id of ids) {
-    miniSearch.discard(`conv:${id}`);
+  const documentIds = [
+    ...ids.map(id => `conv:${id}`),
+    ...messageIds.map(id => `msg:${String(id)}`),
+  ];
+
+  if (isWorkerActive()) {
+    try {
+      const response = await postToWorker('REMOVE', { documentIds });
+      await persistIndex(response.result.serializedIndex);
+      return;
+    } catch (error) {
+      disableWorker(error);
+    }
   }
 
-  for (const messageId of messageIds) {
-    miniSearch.discard(`msg:${messageId}`);
+  if (!fallbackMiniSearch) {
+    return;
   }
 
-  await persistIndex();
+  for (const docId of documentIds) {
+    fallbackMiniSearch.discard(docId);
+  }
+
+  await persistIndex(JSON.stringify(fallbackMiniSearch));
 }

--- a/src/core/workers/searchIndex.worker.ts
+++ b/src/core/workers/searchIndex.worker.ts
@@ -1,0 +1,109 @@
+/// <reference lib="webworker" />
+
+import MiniSearch from 'minisearch';
+import {
+  type SearchDocument,
+  type SearchWorkerRequest,
+  type SearchWorkerResponse,
+} from './searchIndexWorker.types';
+
+const searchOptions = {
+  fields: ['title', 'text'],
+  storeFields: ['conversationId'],
+  idField: 'id' as const,
+};
+
+let miniSearch = createMiniSearch();
+
+function createMiniSearch() {
+  return new MiniSearch<SearchDocument>(searchOptions);
+}
+
+async function handleInit(serializedIndex?: string | null) {
+  if (!serializedIndex) {
+    miniSearch = createMiniSearch();
+    return;
+  }
+
+  miniSearch = await MiniSearch.loadJSONAsync<SearchDocument>(serializedIndex, searchOptions);
+}
+
+async function handleBuildFullIndex(documents: SearchDocument[]) {
+  miniSearch = createMiniSearch();
+  await miniSearch.addAllAsync(documents);
+  return JSON.stringify(miniSearch);
+}
+
+async function handleUpsert(documents: SearchDocument[]) {
+  for (const doc of documents) {
+    if (miniSearch.has(doc.id)) {
+      miniSearch.replace(doc);
+    } else {
+      miniSearch.add(doc);
+    }
+  }
+
+  return JSON.stringify(miniSearch);
+}
+
+async function handleRemove(documentIds: string[]) {
+  for (const id of documentIds) {
+    miniSearch.discard(id);
+  }
+
+  return JSON.stringify(miniSearch);
+}
+
+function handleSearch(query: string) {
+  const results = miniSearch.search(query, { prefix: true, fuzzy: 0.2 });
+  const conversationIds = Array.from(new Set(results.map(result => result.conversationId)));
+  return conversationIds;
+}
+
+declare const self: DedicatedWorkerGlobalScope;
+
+self.onmessage = async (event: MessageEvent<SearchWorkerRequest>) => {
+  const message = event.data as SearchWorkerRequest;
+  const { id, action } = message;
+
+  try {
+    let response: SearchWorkerResponse;
+
+    switch (action) {
+      case 'INIT': {
+        await handleInit(message.payload.serializedIndex);
+        response = { id, action, success: true, result: { ready: true } };
+        break;
+      }
+      case 'BUILD_FULL_INDEX': {
+        const serializedIndex = await handleBuildFullIndex(message.payload.documents);
+        response = { id, action, success: true, result: { serializedIndex } };
+        break;
+      }
+      case 'UPSERT': {
+        const serializedIndex = await handleUpsert(message.payload.documents);
+        response = { id, action, success: true, result: { serializedIndex } };
+        break;
+      }
+      case 'REMOVE': {
+        const serializedIndex = await handleRemove(message.payload.documentIds);
+        response = { id, action, success: true, result: { serializedIndex } };
+        break;
+      }
+      case 'SEARCH': {
+        const conversationIds = handleSearch(message.payload.query);
+        response = { id, action, success: true, result: { conversationIds } };
+        break;
+      }
+      default: {
+        throw new Error(`Unsupported action: ${action satisfies never}`);
+      }
+    }
+
+    self.postMessage(response satisfies SearchWorkerResponse);
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? `${error.name}: ${error.message}` : 'Unknown worker error';
+    self.postMessage({ id, success: false, error: errorMessage });
+  }
+};

--- a/src/core/workers/searchIndexWorker.types.ts
+++ b/src/core/workers/searchIndexWorker.types.ts
@@ -1,0 +1,75 @@
+export interface SearchDocument {
+  id: string;
+  text: string;
+  conversationId: string;
+  title?: string;
+}
+
+export type SearchWorkerRequest =
+  | {
+      id: number;
+      action: 'INIT';
+      payload: { serializedIndex?: string | null };
+    }
+  | {
+      id: number;
+      action: 'BUILD_FULL_INDEX';
+      payload: { documents: SearchDocument[] };
+    }
+  | {
+      id: number;
+      action: 'UPSERT';
+      payload: { documents: SearchDocument[] };
+    }
+  | {
+      id: number;
+      action: 'REMOVE';
+      payload: { documentIds: string[] };
+    }
+  | {
+      id: number;
+      action: 'SEARCH';
+      payload: { query: string };
+    };
+
+export type SearchWorkerSuccessResponse =
+  | {
+      id: number;
+      action: 'INIT';
+      success: true;
+      result: { ready: true };
+    }
+  | {
+      id: number;
+      action: 'BUILD_FULL_INDEX';
+      success: true;
+      result: { serializedIndex: string };
+    }
+  | {
+      id: number;
+      action: 'UPSERT';
+      success: true;
+      result: { serializedIndex: string };
+    }
+  | {
+      id: number;
+      action: 'REMOVE';
+      success: true;
+      result: { serializedIndex: string };
+    }
+  | {
+      id: number;
+      action: 'SEARCH';
+      success: true;
+      result: { conversationIds: string[] };
+    };
+
+export interface SearchWorkerErrorResponse {
+  id: number;
+  success: false;
+  error: string;
+}
+
+export type SearchWorkerResponse =
+  | SearchWorkerSuccessResponse
+  | SearchWorkerErrorResponse;


### PR DESCRIPTION
## Summary
- add a dedicated MiniSearch worker and shared request/response types
- update the search service to delegate heavy indexing to the worker with graceful fallbacks
- refresh the roadmap to mark the worker-driven indexing milestone complete

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11d617b9c83339eae299bda662bc7