### PR TITLE
ci: enable workflow concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add concurrency control to the CI workflow to cancel duplicate runs on new pushes

## Testing
- not run (CI configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e12238f83c83339c50e00f9195d5dc