### PR TITLE
Add timeout to CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add a 20-minute timeout to the CI build job to automatically cancel stalled runs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1223a48bc833390a15650e638f2cb