### PR TITLE
fix: ensure dashboard shortcuts use extension URL

### DIFF
--- a/src/content/textareaPrompts.ts
+++ b/src/content/textareaPrompts.ts
@@ -533,27 +533,31 @@ function renderPromptList() {
 }
 
 function openDashboard() {
+  const dashboardUrl =
+    chrome.runtime?.getURL?.('src/options/index.html') ??
+    chrome.runtime?.getURL?.('options.html');
+
   if (chrome.runtime?.openOptionsPage) {
     chrome.runtime.openOptionsPage(() => {
       const lastError = chrome.runtime?.lastError;
       if (lastError) {
         console.error('[ai-companion] failed to open options page', lastError);
-        const fallbackUrl = chrome.runtime?.getURL?.('options.html');
-        if (fallbackUrl) {
-          window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
+        if (dashboardUrl) {
+          window.open(dashboardUrl, '_blank', 'noopener,noreferrer');
+        } else {
+          console.error('[ai-companion] unable to resolve dashboard URL for fallback navigation');
         }
       }
     });
     return;
   }
 
-  const url = chrome.runtime?.getURL?.('options.html');
-  if (url) {
-    window.open(url, '_blank', 'noopener,noreferrer');
+  if (dashboardUrl) {
+    window.open(dashboardUrl, '_blank', 'noopener,noreferrer');
     return;
   }
 
-  window.open('/options.html', '_blank', 'noopener,noreferrer');
+  console.error('[ai-companion] dashboard URL could not be resolved');
 }
 
 function matchesPrompt(prompt: PromptRecord, term: string) {

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -47,22 +47,35 @@ function formatBookmarkPreview(bookmark: BookmarkSummary, fallback: string) {
 }
 
 function openDashboard() {
+  const dashboardUrl =
+    chrome.runtime?.getURL?.('src/options/index.html') ??
+    chrome.runtime?.getURL?.('options.html');
+
   if (chrome.runtime?.openOptionsPage) {
     chrome.runtime.openOptionsPage(() => {
       const lastError = chrome.runtime.lastError;
       if (lastError) {
         console.error('[ai-companion] failed to open options page', lastError);
+        if (dashboardUrl) {
+          chrome.tabs
+            .create({ url: dashboardUrl })
+            .catch((error) => console.error('[ai-companion] failed to open dashboard tab', error));
+        } else {
+          console.error('[ai-companion] unable to resolve dashboard URL for fallback navigation');
+        }
       }
     });
     return;
   }
 
-  const url = chrome.runtime?.getURL?.('options.html');
-  if (url) {
-    chrome.tabs.create({ url }).catch((error) => {
-      console.error('[ai-companion] failed to open dashboard tab', error);
-    });
+  if (dashboardUrl) {
+    chrome.tabs
+      .create({ url: dashboardUrl })
+      .catch((error) => console.error('[ai-companion] failed to open dashboard tab', error));
+    return;
   }
+
+  console.error('[ai-companion] dashboard URL could not be resolved');
 }
 
 function getActivityAccent(item: ActivityItem) {


### PR DESCRIPTION
## Summary
- update dashboard launchers to resolve the options page with chrome.runtime.getURL and avoid host-relative fallbacks
- add error handling when the options page fails to open and reuse the resolved extension URL across surfaces
- align popup dashboard shortcut with the new resolution logic to keep shortcuts consistent

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16ab0a2ac833390983a52be2091a0