### PR TITLE
feat: show prompt count in prompt launcher toggle

### DIFF
--- a/src/content/textareaPrompts.ts
+++ b/src/content/textareaPrompts.ts
@@ -417,12 +417,9 @@ function applyTranslations() {
     return;
   }
 
-  const promptsLabel = translate('content.dock.prompts', 'Prompts');
-  toggleButtonLabel.textContent = promptsLabel;
+  updatePromptToggleText();
   toggleButton.setAttribute('data-open', state.open ? 'true' : 'false');
   toggleButton.setAttribute('aria-expanded', state.open ? 'true' : 'false');
-  toggleButton.setAttribute('aria-label', translate('content.dock.promptsAria', 'Toggle prompts dock'));
-  toggleButton.setAttribute('title', promptsLabel);
 
   const dashboardLabel = translate('content.dock.dashboard', 'Dashboard');
   dashboardButtonLabel.textContent = dashboardLabel;
@@ -442,6 +439,21 @@ function applyTranslations() {
   emptySubtitleEl.textContent = translate(
     'content.promptLauncher.emptySubtitle',
     'Save prompts in the dashboard or popup to reuse them here.'
+  );
+}
+
+function updatePromptToggleText() {
+  if (!toggleButton || !toggleButtonLabel) {
+    return;
+  }
+
+  const count = state.prompts?.length ?? 0;
+  const promptsLabel = translate('content.dock.prompts', 'Prompts ({{count}})', { count });
+  toggleButtonLabel.textContent = promptsLabel;
+  toggleButton.setAttribute('title', promptsLabel);
+  toggleButton.setAttribute(
+    'aria-label',
+    translate('content.dock.promptsAria', 'Toggle prompts dock ({{count}} available)', { count })
   );
 }
 
@@ -489,6 +501,8 @@ function setOpen(open: boolean) {
 }
 
 function renderPromptList() {
+  updatePromptToggleText();
+
   if (!promptList || !emptyState || !emptyTitleEl || !emptySubtitleEl) {
     return;
   }

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -262,8 +262,8 @@
       "closeAria": "Close prompt launcher"
     },
     "dock": {
-      "prompts": "Prompts",
-      "promptsAria": "Toggle prompts dock",
+      "prompts": "Prompts ({{count}})",
+      "promptsAria": "Toggle prompts dock ({{count}} available)",
       "dashboard": "Dashboard",
       "dashboardAria": "Open dashboard"
     }

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -262,8 +262,8 @@
       "closeAria": "Promptmenu sluiten"
     },
     "dock": {
-      "prompts": "Prompts",
-      "promptsAria": "Promptmenu openen of sluiten",
+      "prompts": "Prompts ({{count}})",
+      "promptsAria": "Promptmenu openen of sluiten ({{count}} beschikbaar)",
       "dashboard": "Dashboard",
       "dashboardAria": "Dashboard openen"
     }


### PR DESCRIPTION
## Summary
- update the prompt launcher toggle to include the number of saved prompts and refresh it after prompt list updates
- refresh English and Dutch localized strings and aria-labels to surface the count accessibly

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16aaf74e883339bcfe36d5a147744