### PR TITLE
fix: stabilize i18n hooks across extension surfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "minisearch": "^7.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-i18next": "^16.0.0",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -2283,15 +2282,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -3077,32 +3067,6 @@
         "react": "^19.2.0"
       }
     },
-    "node_modules/react-i18next": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.0.0.tgz",
-      "integrity": "sha512-JQ+dFfLnFSKJQt7W01lJHWRC0SX7eDPobI+MSTJ3/gP39xH2g33AuTE7iddAfXYHamJdAeMGM0VFboPaD3G68Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "html-parse-stringify": "^3.0.1"
-      },
-      "peerDependencies": {
-        "i18next": ">= 25.5.2",
-        "react": ">= 16.8.0",
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -3859,15 +3823,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.52.4",
         "@rollup/rollup-win32-x64-msvc": "4.52.4",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "minisearch": "^7.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-i18next": "^16.0.0",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -1,7 +1,7 @@
 ﻿import React, { StrictMode, useCallback, useEffect, useId, useMemo, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import { ensureShadowHost } from './sidebar-host';
 import { insertTextIntoComposer } from './textareaPrompts';

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,5 +1,5 @@
 ﻿import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import { HistorySection } from './features/history/HistorySection';
 import { MediaSection } from './features/media/MediaSection';

--- a/src/options/features/history/HistorySection.tsx
+++ b/src/options/features/history/HistorySection.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import type {
   ConversationArchivedFilter,

--- a/src/options/features/media/MediaSection.tsx
+++ b/src/options/features/media/MediaSection.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import { MediaOverlay } from '@/ui/components/MediaOverlay';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/ui/components/Modal';

--- a/src/options/features/prompts/PromptsSection.tsx
+++ b/src/options/features/prompts/PromptsSection.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, Fragment, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import type { GPTRecord, PromptChainRecord, PromptRecord } from '@/core/models';
 import { EmptyState } from '@/shared/components';

--- a/src/options/main.tsx
+++ b/src/options/main.tsx
@@ -1,10 +1,9 @@
 import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
-import { I18nextProvider } from 'react-i18next';
 
 import { Options } from './Options';
 import '@/styles/global.css';
-import { i18n, initI18n } from '@/shared/i18n';
+import { initI18n } from '@/shared/i18n';
 import { initializeSettingsStore } from '@/shared/state/settingsStore';
 
 async function bootstrap() {
@@ -17,9 +16,7 @@ async function bootstrap() {
 
   ReactDOM.createRoot(rootElement).render(
     <StrictMode>
-      <I18nextProvider i18n={i18n}>
-        <Options />
-      </I18nextProvider>
+      <Options />
     </StrictMode>
   );
 }

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,5 +1,5 @@
 ﻿import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import type { ActivityItem, BookmarkSummary } from '@/core/storage';
 import { toggleBookmark, togglePinned } from '@/core/storage';

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -1,5 +1,4 @@
 ﻿import i18n from 'i18next';
-import { initReactI18next } from 'react-i18next';
 
 import en from './locales/en/common.json' with { type: 'json' };
 import nl from './locales/nl/common.json' with { type: 'json' };
@@ -7,7 +6,11 @@ import nl from './locales/nl/common.json' with { type: 'json' };
 let initialized = false;
 
 export async function initI18n(): Promise<typeof i18n> {
-  const targetLanguage = navigator.language?.startsWith('nl') ? 'nl' : 'en';
+  const languageCode =
+    typeof navigator !== 'undefined' && typeof navigator.language === 'string'
+      ? navigator.language
+      : 'en';
+  const targetLanguage = languageCode.startsWith('nl') ? 'nl' : 'en';
 
   if (initialized) {
     if (i18n.language !== targetLanguage) {
@@ -16,7 +19,7 @@ export async function initI18n(): Promise<typeof i18n> {
     return i18n;
   }
 
-  await i18n.use(initReactI18next).init({
+  await i18n.init({
     resources: {
       en: { translation: en },
       nl: { translation: nl }

--- a/src/shared/i18n/useTranslation.ts
+++ b/src/shared/i18n/useTranslation.ts
@@ -1,0 +1,39 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { i18n } from './index';
+
+type Translate = typeof i18n.t;
+
+type UseTranslationResult = {
+  t: Translate;
+  i18n: typeof i18n;
+  language: string;
+  ready: boolean;
+};
+
+function subscribe(listener: () => void) {
+  i18n.on('languageChanged', listener);
+  return () => {
+    i18n.off('languageChanged', listener);
+  };
+}
+
+function getLanguage() {
+  return i18n.language ?? 'en';
+}
+
+export function useTranslation(): UseTranslationResult {
+  const language = useSyncExternalStore(subscribe, getLanguage, getLanguage);
+
+  const translate = useCallback<Translate>(
+    ((...args: Parameters<Translate>) => i18n.t(...args)) as Translate,
+    [language]
+  );
+
+  return {
+    t: translate,
+    i18n,
+    language,
+    ready: true
+  };
+}


### PR DESCRIPTION
## Summary
- replace react-i18next usage with a shared translation hook that listens to i18next language changes
- remove the I18nextProvider wrapper and guard i18n initialization for non-browser environments across options, popup, and content surfaces
- update project dependencies after dropping react-i18next

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e175d5ead0833393f7afe2612a1949