### PR TITLE
fix: stabilize settings selectors

### DIFF
--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -553,10 +553,8 @@ interface CompanionSidebarRootProps {
 }
 
 function CompanionSidebarRoot({ host }: CompanionSidebarRootProps): ReactElement | null {
-  const { hydrated, showSidebar } = useSettingsStore((state) => ({
-    hydrated: state.hydrated,
-    showSidebar: state.showSidebar
-  }));
+  const hydrated = useSettingsStore((state) => state.hydrated);
+  const showSidebar = useSettingsStore((state) => state.showSidebar);
 
   useEffect(() => {
     const shouldShow = hydrated && showSidebar;

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -36,10 +36,8 @@ const featureColumns = [
 
 export function Options() {
   const { t } = useTranslation();
-  const { direction, hydrated } = useSettingsStore((state) => ({
-    direction: state.direction,
-    hydrated: state.hydrated
-  }));
+  const direction = useSettingsStore((state) => state.direction);
+  const hydrated = useSettingsStore((state) => state.hydrated);
   const [isSchedulingExport, setIsSchedulingExport] = useState(false);
   const [optimisticExportAt, setOptimisticExportAt] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -8,8 +8,8 @@ import { useRecentActivity } from '@/shared/hooks/useRecentActivity';
 import { useRecentBookmarks } from '@/shared/hooks/useRecentBookmarks';
 import { useRecentConversations } from '@/shared/hooks/useRecentConversations';
 import { initI18n, setLanguage } from '@/shared/i18n';
-import { useSettingsStore } from '@/shared/state/settingsStore';
 import { sendRuntimeMessage } from '@/shared/messaging/router';
+import { useSettingsStore } from '@/shared/state/settingsStore';
 
 const languageOptions = [
   { code: 'en', label: 'English' },
@@ -100,19 +100,11 @@ function getActivityAccent(item: ActivityItem) {
 
 export function Popup() {
   const { t, i18n } = useTranslation();
-  const {
-    language,
-    direction,
-    setLanguage: setStoreLanguage,
-    toggleDirection,
-    hydrated
-  } = useSettingsStore((state) => ({
-    language: state.language,
-    direction: state.direction,
-    setLanguage: state.setLanguage,
-    toggleDirection: state.toggleDirection,
-    hydrated: state.hydrated
-  }));
+  const language = useSettingsStore((state) => state.language);
+  const direction = useSettingsStore((state) => state.direction);
+  const setStoreLanguage = useSettingsStore((state) => state.setLanguage);
+  const toggleDirection = useSettingsStore((state) => state.toggleDirection);
+  const hydrated = useSettingsStore((state) => state.hydrated);
   const conversations = useRecentConversations(5);
   const pinnedConversations = usePinnedConversations(4);
   const recentBookmarks = useRecentBookmarks(4);


### PR DESCRIPTION
## Summary
- update the options dashboard to read settings store fields with stable selectors
- split popup settings store usage into dedicated selectors to avoid object recreation
- fetch sidebar hydration flags individually to prevent unnecessary rerenders

## Testing
- CI=1 npm run dev -- --clearScreen false
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1782316848333b4c5ec5a2f346af9