### PR TITLE
fix: ensure sidebar preference hydration and reactive mounting

### DIFF
--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -675,16 +675,14 @@ function CompanionSidebar(): ReactElement {
 
 async function init() {
   await initializeSettingsStore();
-  if (!useSettingsStore.getState().showSidebar) {
-    return;
-  }
 
   const host = await ensureShadowHost();
+  host.style.display = 'none';
   const container = mountReact(host);
   const root = createRoot(container);
   root.render(
     <StrictMode>
-      <CompanionSidebar />
+      <CompanionSidebarRoot host={host} />
     </StrictMode>
   );
 }

--- a/src/shared/state/settingsStore.ts
+++ b/src/shared/state/settingsStore.ts
@@ -32,7 +32,8 @@ function coerceSnapshot(input: unknown): SettingsSnapshot {
   const record = input as Partial<SettingsSnapshot>;
   const language = typeof record.language === 'string' ? record.language : DEFAULT_SNAPSHOT.language;
   const direction: TextDirection = record.direction === 'rtl' ? 'rtl' : 'ltr';
-  const showSidebar = false;
+  const showSidebar =
+    typeof record.showSidebar === 'boolean' ? record.showSidebar : DEFAULT_SNAPSHOT.showSidebar;
 
   return { language, direction, showSidebar };
 }


### PR DESCRIPTION
## Summary
- preserve the stored `showSidebar` setting when hydrating the settings store
- mount the reactive sidebar root so visibility toggles apply without reloading

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17c44dcf48333a2aee2cf93aede38