### PR TITLE
feat(options): refresh filters and prompts with bubble controls

### DIFF
--- a/src/options/features/history/HistorySection.tsx
+++ b/src/options/features/history/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import type {
@@ -14,12 +14,7 @@ import { useConversationPresets } from '@/shared/hooks/useConversationPresets';
 import { useFolderTree } from '@/shared/hooks/useFolderTree';
 import { useRecentConversations } from '@/shared/hooks/useRecentConversations';
 
-import {
-  FolderTreeList,
-  flattenFolderOptions,
-  formatDate,
-  formatNumber
-} from '../shared';
+import { OptionBubble, flattenFolderOptions, formatDate, formatNumber } from '../shared';
 import { useHistoryStore } from './historyStore';
 
 export function HistorySection() {
@@ -47,6 +42,8 @@ export function HistorySection() {
     () => flattenFolderOptions(conversationFolders),
     [conversationFolders]
   );
+
+  const [showConversationFolderForm, setShowConversationFolderForm] = useState(false);
 
   const filteredConversations = useMemo(() => {
     const filtered = conversations.filter((conversation) => {
@@ -131,6 +128,7 @@ export function HistorySection() {
   const handleCreateConversationFolder = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     await createConversationFolder();
+    setShowConversationFolderForm(false);
   };
 
   const handleDeleteConversationPreset = async (presetId: string) => {
@@ -150,215 +148,322 @@ export function HistorySection() {
   };
 
   return (
-    <section className="grid gap-6 lg:grid-cols-[280px_1fr]" aria-labelledby="history-heading">
-      <aside>
-        <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-          <header className="space-y-1">
-            <h2 id="history-heading" className="text-base font-semibold text-emerald-300">
-              {t('options.conversationFolderHeading')}
-            </h2>
-            <p className="text-xs text-slate-400">{t('options.conversationFolderDescription')}</p>
-          </header>
-          <form className="flex flex-col gap-2" onSubmit={handleCreateConversationFolder}>
-            <label className="text-xs font-medium uppercase tracking-wide text-slate-400" htmlFor="conversation-folder-name">
-              {t('options.addFolder')}
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
-                id="conversation-folder-name"
-                placeholder={t('options.folderNamePlaceholder') ?? ''}
-                value={conversationFolderName}
-                onChange={(event) => setConversationFolderName(event.target.value)}
-              />
-              <button
-                className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                type="submit"
-              >
-                {t('options.addFolderButton')}
-              </button>
-            </div>
-          </form>
-          <div className="space-y-2" role="tree" aria-label={t('options.conversationFolderHeading')}>
-            <FolderTreeList
-              nodes={conversationFolders}
-              deleteLabel={t('options.deleteButton') ?? ''}
-              onDelete={deleteConversationFolder}
-            />
-          </div>
-        </div>
-      </aside>
+    <section className="space-y-6" aria-labelledby="history-heading">
+      <header className="space-y-2">
+        <h2 id="history-heading" className="text-lg font-semibold text-emerald-300">
+          {t('options.conversationHeading')}
+        </h2>
+        <p className="text-sm text-slate-300">{t('options.conversationDescription')}</p>
+      </header>
 
       <div className="space-y-6">
-        <header>
-          <h2 className="text-lg font-semibold text-emerald-300">{t('options.conversationHeading')}</h2>
-          <p className="text-sm text-slate-300">{t('options.conversationDescription')}</p>
-        </header>
+        <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+          <header className="space-y-1">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-200">
+              {t('options.conversationFiltersHeading')}
+            </h3>
+            <p className="text-xs text-slate-400">{t('options.conversationFiltersDescription')}</p>
+          </header>
 
-        <div className="grid gap-4 lg:grid-cols-2">
-          <div className="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
-            <h3 className="text-sm font-semibold text-emerald-200">{t('options.filterHeading')}</h3>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="flex flex-col gap-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-filter-folder">
-                  {t('options.filterFolderLabel')}
-                </label>
-                <select
-                  className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                  id="conversation-filter-folder"
-                  value={conversationConfig.folderId}
-                  onChange={(event) =>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                {t('options.filterFolderLabel')}
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <OptionBubble
+                  selected={conversationConfig.folderId === 'all'}
+                  onClick={() =>
                     handleConversationConfigChange({
-                      folderId: event.target.value as ConversationTableConfig['folderId']
+                      folderId: 'all'
                     })
                   }
                 >
-                  <option value="all">{t('options.filterFolderAll')}</option>
-                  {conversationFolderOptions.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {`${'— '.repeat(option.depth)}${option.name}`}
-                    </option>
-                  ))}
-                </select>
+                  {t('options.filterFolderAll')}
+                </OptionBubble>
+                {conversationFolderOptions.map((option) => (
+                  <OptionBubble
+                    key={option.id}
+                    selected={conversationConfig.folderId === option.id}
+                    onClick={() =>
+                      handleConversationConfigChange({
+                        folderId: option.id as ConversationTableConfig['folderId']
+                      })
+                    }
+                    onRemove={() => void deleteConversationFolder(option.id)}
+                    removeLabel={t('options.deleteFolder') ?? undefined}
+                  >
+                    <span className="flex items-center gap-2">
+                      {option.depth > 0 ? (
+                        <span className="text-xs text-slate-500">{'•'.repeat(option.depth)}</span>
+                      ) : null}
+                      <span>{option.name}</span>
+                    </span>
+                  </OptionBubble>
+                ))}
+                <OptionBubble
+                  selected={showConversationFolderForm}
+                  aria-label={t('options.addFolder') ?? 'Add folder'}
+                  aria-expanded={showConversationFolderForm}
+                  onClick={() => setShowConversationFolderForm((previous) => !previous)}
+                >
+                  +
+                </OptionBubble>
               </div>
-              <div className="flex flex-col gap-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-filter-pinned">
-                  {t('options.filterPinnedLabel')}
-                </label>
-                <select
-                  className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                  id="conversation-filter-pinned"
-                  value={conversationConfig.pinned}
-                  onChange={(event) =>
+              {showConversationFolderForm ? (
+                <form className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-3" onSubmit={handleCreateConversationFolder}>
+                  <label className="text-xs font-medium uppercase tracking-wide text-slate-400" htmlFor="conversation-folder-name">
+                    {t('options.addFolder')}
+                  </label>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <input
+                      className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+                      id="conversation-folder-name"
+                      placeholder={t('options.folderNamePlaceholder') ?? ''}
+                      value={conversationFolderName}
+                      onChange={(event) => setConversationFolderName(event.target.value)}
+                    />
+                    <div className="flex gap-2 sm:w-auto">
+                      <button
+                        className="flex-1 rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 sm:flex-none"
+                        onClick={() => setShowConversationFolderForm(false)}
+                        type="button"
+                      >
+                        {t('options.cancelButton')}
+                      </button>
+                      <button
+                        className="flex-1 rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm sm:flex-none"
+                        type="submit"
+                      >
+                        {t('options.addFolderButton')}
+                      </button>
+                    </div>
+                  </div>
+                </form>
+              ) : null}
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                {t('options.filterPinnedLabel')}
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <OptionBubble
+                  selected={conversationConfig.pinned === 'all'}
+                  onClick={() =>
                     handleConversationConfigChange({
-                      pinned: event.target.value as ConversationPinnedFilter
+                      pinned: 'all' as ConversationPinnedFilter
                     })
                   }
                 >
-                  <option value="all">{t('options.filterPinnedAll')}</option>
-                  <option value="pinned">{t('options.filterPinnedOnly')}</option>
-                  <option value="unpinned">{t('options.filterPinnedExclude')}</option>
-                </select>
+                  {t('options.filterPinnedAll')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.pinned === 'pinned'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      pinned: 'pinned' as ConversationPinnedFilter
+                    })
+                  }
+                >
+                  {t('options.filterPinnedOnly')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.pinned === 'unpinned'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      pinned: 'unpinned' as ConversationPinnedFilter
+                    })
+                  }
+                >
+                  {t('options.filterPinnedExclude')}
+                </OptionBubble>
               </div>
-              <div className="flex flex-col gap-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-filter-archived">
-                  {t('options.filterArchivedLabel')}
-                </label>
-                <select
-                  className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                  id="conversation-filter-archived"
-                  value={conversationConfig.archived}
-                  onChange={(event) =>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                {t('options.filterArchivedLabel')}
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <OptionBubble
+                  selected={conversationConfig.archived === 'all'}
+                  onClick={() =>
                     handleConversationConfigChange({
-                      archived: event.target.value as ConversationArchivedFilter
+                      archived: 'all' as ConversationArchivedFilter
                     })
                   }
                 >
-                  <option value="all">{t('options.filterArchivedAll')}</option>
-                  <option value="active">{t('options.filterArchivedActive')}</option>
-                  <option value="archived">{t('options.filterArchivedOnly')}</option>
-                </select>
+                  {t('options.filterArchivedAll')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.archived === 'active'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      archived: 'active' as ConversationArchivedFilter
+                    })
+                  }
+                >
+                  {t('options.filterArchivedActive')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.archived === 'archived'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      archived: 'archived' as ConversationArchivedFilter
+                    })
+                  }
+                >
+                  {t('options.filterArchivedOnly')}
+                </OptionBubble>
               </div>
-              <div className="flex flex-col gap-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-sort-field">
-                  {t('options.sortFieldLabel')}
-                </label>
-                <select
-                  className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                  id="conversation-sort-field"
-                  value={conversationConfig.sortField}
-                  onChange={(event) =>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                {t('options.sortFieldLabel')}
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <OptionBubble
+                  selected={conversationConfig.sortField === 'updatedAt'}
+                  onClick={() =>
                     handleConversationConfigChange({
-                      sortField: event.target.value as ConversationSortField
+                      sortField: 'updatedAt' as ConversationSortField
                     })
                   }
                 >
-                  <option value="updatedAt">{t('options.sortUpdated')}</option>
-                  <option value="title">{t('options.sortTitle')}</option>
-                  <option value="messageCount">{t('options.sortMessages')}</option>
-                  <option value="wordCount">{t('options.sortWords')}</option>
-                  <option value="charCount">{t('options.sortCharacters')}</option>
-                </select>
+                  {t('options.sortUpdated')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.sortField === 'title'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      sortField: 'title' as ConversationSortField
+                    })
+                  }
+                >
+                  {t('options.sortTitle')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.sortField === 'messageCount'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      sortField: 'messageCount' as ConversationSortField
+                    })
+                  }
+                >
+                  {t('options.sortMessages')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.sortField === 'wordCount'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      sortField: 'wordCount' as ConversationSortField
+                    })
+                  }
+                >
+                  {t('options.sortWords')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.sortField === 'charCount'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      sortField: 'charCount' as ConversationSortField
+                    })
+                  }
+                >
+                  {t('options.sortCharacters')}
+                </OptionBubble>
               </div>
-              <div className="flex flex-col gap-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-sort-direction">
-                  {t('options.sortDirectionLabel')}
-                </label>
-                <select
-                  className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                  id="conversation-sort-direction"
-                  value={conversationConfig.sortDirection}
-                  onChange={(event) =>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                {t('options.sortDirectionLabel')}
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <OptionBubble
+                  selected={conversationConfig.sortDirection === 'desc'}
+                  onClick={() =>
                     handleConversationConfigChange({
-                      sortDirection: event.target.value as ConversationSortDirection
+                      sortDirection: 'desc' as ConversationSortDirection
                     })
                   }
                 >
-                  <option value="desc">{t('options.sortDirectionDesc')}</option>
-                  <option value="asc">{t('options.sortDirectionAsc')}</option>
-                </select>
+                  {t('options.sortDirectionDesc')}
+                </OptionBubble>
+                <OptionBubble
+                  selected={conversationConfig.sortDirection === 'asc'}
+                  onClick={() =>
+                    handleConversationConfigChange({
+                      sortDirection: 'asc' as ConversationSortDirection
+                    })
+                  }
+                >
+                  {t('options.sortDirectionAsc')}
+                </OptionBubble>
               </div>
             </div>
           </div>
-          <div className="space-y-3 rounded-lg border border-slate-800 bg-slate-950/40 p-3">
-            <header className="space-y-1">
-              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400">{t('options.presetHeading')}</h4>
-              <p className="text-xs text-slate-500">{t('options.presetDescription')}</p>
-            </header>
-            <form className="flex flex-col gap-2 md:flex-row md:items-end md:gap-3" onSubmit={handleSavePreset}>
-              <div className="flex-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-preset-name">
-                  {t('options.presetNameLabel')}
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
-                  id="conversation-preset-name"
-                  placeholder={t('options.presetNamePlaceholder') ?? ''}
-                  value={presetName}
-                  onChange={(event) => setPresetName(event.target.value)}
-                />
-              </div>
-              <button
-                className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm md:self-start"
-                type="submit"
-              >
-                {t('options.presetSaveButton')}
-              </button>
-            </form>
-            {conversationPresets.length === 0 ? (
-              <EmptyState title={t('options.presetEmpty')} align="start" className="py-4 text-xs" />
-            ) : (
-              <ul className="space-y-2">
-                {conversationPresets.map((preset) => (
-                  <li
-                    key={preset.id}
-                    className="flex flex-col gap-3 rounded-md border border-slate-800 bg-slate-900/60 p-3 sm:flex-row sm:items-center sm:justify-between"
-                  >
-                    <div className="space-y-1">
-                      <p className="text-sm font-medium text-slate-100">{preset.name}</p>
-                      <p className="text-xs text-slate-500">{formatDate(preset.updatedAt)}</p>
-                    </div>
-                    <div className="flex gap-2 sm:justify-end">
-                      <button
-                        className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
-                        onClick={() => handleApplyConversationPreset(preset)}
-                        type="button"
-                      >
-                        {t('options.presetApplyButton')}
-                      </button>
-                      <button
-                        className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
-                        onClick={() => void handleDeleteConversationPreset(preset.id)}
-                        type="button"
-                      >
-                        {t('options.presetDeleteButton')}
-                      </button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+        </div>
+
+        <div className="space-y-3 rounded-lg border border-slate-800 bg-slate-950/40 p-3">
+          <header className="space-y-1">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400">{t('options.presetHeading')}</h4>
+            <p className="text-xs text-slate-500">{t('options.presetDescription')}</p>
+          </header>
+          <form className="flex flex-col gap-2 md:flex-row md:items-end md:gap-3" onSubmit={handleSavePreset}>
+            <div className="flex-1">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="conversation-preset-name">
+                {t('options.presetNameLabel')}
+              </label>
+              <input
+                className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+                id="conversation-preset-name"
+                placeholder={t('options.presetNamePlaceholder') ?? ''}
+                value={presetName}
+                onChange={(event) => setPresetName(event.target.value)}
+              />
+            </div>
+            <button
+              className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm md:self-start"
+              type="submit"
+            >
+              {t('options.presetSaveButton')}
+            </button>
+          </form>
+          {conversationPresets.length === 0 ? (
+            <EmptyState title={t('options.presetEmpty')} align="start" className="py-4 text-xs" />
+          ) : (
+            <ul className="space-y-2">
+              {conversationPresets.map((preset) => (
+                <li
+                  key={preset.id}
+                  className="flex flex-col gap-3 rounded-md border border-slate-800 bg-slate-900/60 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-slate-100">{preset.name}</p>
+                    <p className="text-xs text-slate-500">{formatDate(preset.updatedAt)}</p>
+                  </div>
+                  <div className="flex gap-2 sm:justify-end">
+                    <button
+                      className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+                      onClick={() => handleApplyConversationPreset(preset)}
+                      type="button"
+                    >
+                      {t('options.presetApplyButton')}
+                    </button>
+                    <button
+                      className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
+                      onClick={() => void handleDeleteConversationPreset(preset.id)}
+                      type="button"
+                    >
+                      {t('options.presetDeleteButton')}
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
 
         <div className="overflow-hidden rounded-xl border border-slate-800">
@@ -422,4 +527,5 @@ export function HistorySection() {
       </div>
     </section>
   );
+
 }

--- a/src/options/features/prompts/PromptsSection.tsx
+++ b/src/options/features/prompts/PromptsSection.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, Fragment, useMemo } from 'react';
+import { FormEvent, Fragment, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '@/shared/i18n/useTranslation';
 
 import type { GPTRecord, PromptChainRecord, PromptRecord } from '@/core/models';
@@ -9,7 +9,8 @@ import { useGpts } from '@/shared/hooks/useGpts';
 import { usePromptChains } from '@/shared/hooks/usePromptChains';
 import { usePrompts } from '@/shared/hooks/usePrompts';
 
-import { FolderTreeList, flattenFolderOptions, formatDate, formatNumber, truncate } from '../shared';
+import { OptionBubble, flattenFolderOptions, formatDate, formatNumber, truncate } from '../shared';
+import type { FolderOption } from '../shared';
 import { Tabs, Tab, TabList, TabPanel, TabPanels } from '@/ui/components/Tabs';
 import { usePromptsStore } from './promptsStore';
 
@@ -76,6 +77,57 @@ export function PromptsSection() {
   const gptFolderOptions = useMemo(() => flattenFolderOptions(gptFolderTree), [gptFolderTree]);
   const promptFolderOptions = useMemo(() => flattenFolderOptions(promptFolderTree), [promptFolderTree]);
 
+  const [showGptFolderForm, setShowGptFolderForm] = useState(false);
+  const [showPromptFolderForm, setShowPromptFolderForm] = useState(false);
+  const [showPromptChainManager, setShowPromptChainManager] = useState(false);
+
+  useEffect(() => {
+    if (editingPromptChain) {
+      setShowPromptChainManager(true);
+    }
+  }, [editingPromptChain]);
+
+  const renderFolderLabel = (option: FolderOption) => (
+    <span className="flex items-center gap-2">
+      {option.depth > 0 ? <span className="text-xs text-slate-500">{'•'.repeat(option.depth)}</span> : null}
+      <span>{option.name}</span>
+    </span>
+  );
+
+  const createFolderBubbleItems = (
+    options: FolderOption[],
+    selectedId: string,
+    onSelect: (id: string) => void,
+    allowDelete = false,
+    onDelete?: (id: string) => Promise<void> | void
+  ) => [
+    <OptionBubble key="__none__" selected={selectedId === ''} onClick={() => onSelect('')}>
+      {t('options.noneOption')}
+    </OptionBubble>,
+    ...options.map((option) => (
+      <OptionBubble
+        key={option.id}
+        selected={selectedId === option.id}
+        onClick={() => onSelect(option.id)}
+        onRemove={allowDelete && onDelete ? () => void onDelete(option.id) : undefined}
+        removeLabel={allowDelete && onDelete ? t('options.deleteFolder') ?? undefined : undefined}
+      >
+        {renderFolderLabel(option)}
+      </OptionBubble>
+    ))
+  ];
+
+  const createGptBubbleItems = (selectedId: string, onSelect: (id: string) => void) => [
+    <OptionBubble key="__none__" selected={selectedId === ''} onClick={() => onSelect('')}>
+      {t('options.noneOption')}
+    </OptionBubble>,
+    ...gpts.map((gpt) => (
+      <OptionBubble key={gpt.id} selected={selectedId === gpt.id} onClick={() => onSelect(gpt.id)}>
+        {gpt.name}
+      </OptionBubble>
+    ))
+  ];
+
   const gptFolderNameById = useMemo(() => {
     const map = new Map<string, string>();
     gptFolders.forEach((folder) => {
@@ -119,6 +171,18 @@ export function PromptsSection() {
     return map;
   }, [promptFolders]);
 
+  const activeGptFolderName = gptFolderId
+    ? gptFolderNameById.get(gptFolderId) ?? t('options.noneOption')
+    : t('options.noneOption');
+
+  const activePromptFolderName = promptFolderId
+    ? promptFolderNameById.get(promptFolderId) ?? t('options.noneOption')
+    : t('options.noneOption');
+
+  const activePromptGptName = promptGptId
+    ? gptById.get(promptGptId)?.name ?? t('options.noneOption')
+    : t('options.noneOption');
+
   const selectedChainPrompts = useMemo(() => {
     return promptChainNodeIds
       .map((id) => promptById.get(id))
@@ -128,6 +192,18 @@ export function PromptsSection() {
   const availableChainPrompts = useMemo(() => {
     return prompts.filter((prompt) => !promptChainNodeIds.includes(prompt.id));
   }, [prompts, promptChainNodeIds]);
+
+  const handleCreateGptFolder = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await createGptFolder();
+    setShowGptFolderForm(false);
+  };
+
+  const handleCreatePromptFolder = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await createPromptFolder();
+    setShowPromptFolderForm(false);
+  };
 
   const handleCreateGpt = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -152,25 +228,12 @@ export function PromptsSection() {
   const handleSavePromptChain = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     await savePromptChain();
+    setShowPromptChainManager(false);
   };
 
   const handleEditPromptChain = (chain: PromptChainRecord) => {
     loadPromptChain(chain);
   };
-
-  const renderGptTree =
-    gptFolderTree.length === 0 ? (
-      <EmptyState title={t('options.folderEmpty')} align="start" className="px-4 py-6 text-sm" />
-    ) : (
-      <FolderTreeList nodes={gptFolderTree} deleteLabel={t('options.deleteFolder')} onDelete={deleteGptFolder} />
-    );
-
-  const renderPromptTree =
-    promptFolderTree.length === 0 ? (
-      <EmptyState title={t('options.folderEmpty')} align="start" className="px-4 py-6 text-sm" />
-    ) : (
-      <FolderTreeList nodes={promptFolderTree} deleteLabel={t('options.deleteFolder')} onDelete={deletePromptFolder} />
-    );
 
   return (
     <section className="space-y-6" aria-labelledby="prompts-heading">
@@ -185,22 +248,35 @@ export function PromptsSection() {
         <TabList>
           <Tab value="gpts">{t('options.gptHeading')}</Tab>
           <Tab value="prompts">{t('options.promptHeading')}</Tab>
-          <Tab value="chains">{t('options.promptChainHeading')}</Tab>
         </TabList>
         <TabPanels className="border border-slate-800 bg-slate-900/40 p-4">
           <TabPanel value="gpts" labelledBy="gpt-panel">
-            <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
-              <aside>
-                <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-                  <header className="space-y-1">
-                    <h3 className="text-base font-semibold text-emerald-300">{t('options.gptFolderHeading')}</h3>
-                    <p className="text-xs text-slate-400">{t('options.gptFolderDescription')}</p>
-                  </header>
-                  <form className="flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); void createGptFolder(); }}>
+            <div className="space-y-6">
+              <div className="space-y-3 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                <header className="space-y-1">
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-200">{t('options.gptFolderHeading')}</h3>
+                  <p className="text-xs text-slate-400">{t('options.gptFolderDescription')}</p>
+                </header>
+                <div className="flex flex-wrap gap-3">
+                  {createFolderBubbleItems(gptFolderOptions, gptFolderId, setGptFolderId, true, deleteGptFolder)}
+                  <OptionBubble
+                    selected={showGptFolderForm}
+                    aria-label={t('options.addFolder') ?? 'Add folder'}
+                    aria-expanded={showGptFolderForm}
+                    onClick={() => setShowGptFolderForm((previous) => !previous)}
+                  >
+                    +
+                  </OptionBubble>
+                </div>
+                {gptFolderOptions.length === 0 ? (
+                  <p className="text-xs text-slate-500">{t('options.folderEmpty')}</p>
+                ) : null}
+                {showGptFolderForm ? (
+                  <form className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-3" onSubmit={handleCreateGptFolder}>
                     <label className="text-xs font-medium uppercase tracking-wide text-slate-400" htmlFor="gpt-folder-name">
                       {t('options.addFolder')}
                     </label>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                       <input
                         className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
                         id="gpt-folder-name"
@@ -208,320 +284,490 @@ export function PromptsSection() {
                         value={gptFolderName}
                         onChange={(event) => setGptFolderName(event.target.value)}
                       />
-                      <button
-                        className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                        type="submit"
-                      >
-                        {t('options.addFolderButton')}
-                      </button>
+                      <div className="flex gap-2 sm:w-auto">
+                        <button
+                          className="flex-1 rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 sm:flex-none"
+                          onClick={() => setShowGptFolderForm(false)}
+                          type="button"
+                        >
+                          {t('options.cancelButton')}
+                        </button>
+                        <button
+                          className="flex-1 rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm sm:flex-none"
+                          type="submit"
+                        >
+                          {t('options.addFolderButton')}
+                        </button>
+                      </div>
                     </div>
                   </form>
-                  <div className="space-y-2" role="tree" aria-label={t('options.gptFolderHeading')}>
-                    {renderGptTree}
-                  </div>
-                </div>
-              </aside>
-              <div className="space-y-4">
-                <header>
+                ) : null}
+              </div>
+
+              <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                <header className="space-y-1">
                   <h3 className="text-lg font-semibold text-emerald-300">{t('options.gptHeading')}</h3>
                   <p className="text-sm text-slate-300">{t('options.gptDescription')}</p>
                 </header>
-                <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-                  <form className="space-y-3" onSubmit={handleCreateGpt}>
-                    <div className="grid gap-3 md:grid-cols-2">
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gpt-name">
-                          {t('options.gptNameLabel')}
-                        </label>
-                        <input
-                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
-                          id="gpt-name"
-                          value={gptName}
-                          onChange={(event) => setGptName(event.target.value)}
-                        />
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gpt-folder">
-                          {t('options.gptFolderSelectLabel')}
-                        </label>
-                        <select
-                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                          id="gpt-folder"
-                          value={gptFolderId}
-                          onChange={(event) => setGptFolderId(event.target.value)}
-                        >
-                          <option value="">{t('options.noneOption')}</option>
-                          {gptFolderOptions.map((option) => (
-                            <option key={option.id} value={option.id}>
-                              {`${'— '.repeat(option.depth)}${option.name}`}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    </div>
+                <form className="space-y-4" onSubmit={handleCreateGpt}>
+                  <div className="grid gap-3 md:grid-cols-2">
                     <div className="flex flex-col gap-2">
-                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gpt-description">
-                        {t('options.gptDescriptionLabel')}
+                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gpt-name">
+                        {t('options.gptNameLabel')}
                       </label>
-                      <textarea
-                        className="min-h-[80px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
-                        id="gpt-description"
-                        value={gptDescription}
-                        onChange={(event) => setGptDescription(event.target.value)}
+                      <input
+                        className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+                        id="gpt-name"
+                        value={gptName}
+                        onChange={(event) => setGptName(event.target.value)}
                       />
                     </div>
-                    <button
-                      className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                      type="submit"
-                    >
-                      {t('options.createButton')}
-                    </button>
-                  </form>
-                </div>
-                <div className="overflow-hidden rounded-xl border border-slate-800">
-                  <table className="min-w-full divide-y divide-slate-800 text-sm">
-                    <thead className="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-400">
+                    <div className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                        {t('options.gptFolderSelectLabel')}
+                      </p>
+                      <div className="flex flex-wrap gap-3">
+                        {createFolderBubbleItems(gptFolderOptions, gptFolderId, setGptFolderId)}
+                      </div>
+                      <p className="text-xs text-slate-500">
+                        {t('options.gptFolderActiveLabel', { name: activeGptFolderName })}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gpt-description">
+                      {t('options.gptDescriptionLabel')}
+                    </label>
+                    <textarea
+                      className="min-h-[80px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+                      id="gpt-description"
+                      value={gptDescription}
+                      onChange={(event) => setGptDescription(event.target.value)}
+                    />
+                  </div>
+                  <button
+                    className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
+                    type="submit"
+                  >
+                    {t('options.createButton')}
+                  </button>
+                </form>
+              </div>
+
+              <div className="overflow-hidden rounded-xl border border-slate-800">
+                <table className="min-w-full divide-y divide-slate-800 text-sm">
+                  <thead className="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-400">
+                    <tr>
+                      <th className="px-4 py-3">{t('options.columnTitle')}</th>
+                      <th className="px-4 py-3">{t('options.gptFolderColumn')}</th>
+                      <th className="px-4 py-3">{t('options.promptCountColumn')}</th>
+                      <th className="px-4 py-3">{t('options.columnUpdated')}</th>
+                      <th className="px-4 py-3 text-right">{t('options.columnActions')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-900/60">
+                    {gpts.length === 0 ? (
                       <tr>
-                        <th className="px-4 py-3">{t('options.columnTitle')}</th>
-                        <th className="px-4 py-3">{t('options.gptFolderColumn')}</th>
-                        <th className="px-4 py-3">{t('options.promptCountColumn')}</th>
-                        <th className="px-4 py-3">{t('options.columnUpdated')}</th>
-                        <th className="px-4 py-3 text-right">{t('options.columnActions')}</th>
+                        <td className="px-4 py-6" colSpan={5}>
+                          <EmptyState title={t('options.gptEmpty')} align="start" className="py-8" />
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody className="divide-y divide-slate-900/60">
-                      {gpts.length === 0 ? (
-                        <tr>
-                          <td className="px-4 py-6" colSpan={5}>
-                            <EmptyState title={t('options.gptEmpty')} align="start" className="py-8" />
-                          </td>
-                        </tr>
-                      ) : (
-                        gpts.map((gpt) => (
-                          <Fragment key={gpt.id}>
-                            {editingGpt?.id === gpt.id ? (
-                              <tr className="bg-slate-900/40">
-                                <td colSpan={5} className="px-4 py-3">
-                                  <form className="space-y-3" onSubmit={handleSaveGpt}>
-                                    <div className="grid gap-3 md:grid-cols-2">
-                                      <div className="flex flex-col gap-2">
-                                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-gpt-name">
-                                          {t('options.gptNameLabel')}
-                                        </label>
-                                        <input
-                                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                          id="edit-gpt-name"
-                                          value={editingGpt.name}
-                                          onChange={(event) =>
-                                            updateEditingGpt((previous) => ({ ...previous, name: event.target.value }))
-                                          }
-                                        />
-                                      </div>
-                                      <div className="flex flex-col gap-2">
-                                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-gpt-folder">
-                                          {t('options.gptFolderSelectLabel')}
-                                        </label>
-                                        <select
-                                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                          id="edit-gpt-folder"
-                                          value={editingGpt.folderId}
-                                          onChange={(event) =>
-                                            updateEditingGpt((previous) => ({ ...previous, folderId: event.target.value }))
-                                          }
-                                        >
-                                          <option value="">{t('options.noneOption')}</option>
-                                          {gptFolderOptions.map((option) => (
-                                            <option key={option.id} value={option.id}>
-                                              {`${'— '.repeat(option.depth)}${option.name}`}
-                                            </option>
-                                          ))}
-                                        </select>
-                                      </div>
-                                    </div>
+                    ) : (
+                      gpts.map((gpt) => (
+                        <Fragment key={gpt.id}>
+                          {editingGpt?.id === gpt.id ? (
+                            <tr className="bg-slate-900/40">
+                              <td colSpan={5} className="px-4 py-3">
+                                <form className="space-y-4" onSubmit={handleSaveGpt}>
+                                  <div className="grid gap-3 md:grid-cols-2">
                                     <div className="flex flex-col gap-2">
-                                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-gpt-description">
-                                        {t('options.gptDescriptionLabel')}
+                                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`edit-gpt-name-${gpt.id}`}>
+                                        {t('options.gptNameLabel')}
                                       </label>
-                                      <textarea
-                                        className="min-h-[80px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                        id="edit-gpt-description"
-                                        value={editingGpt.description}
+                                      <input
+                                        className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                                        id={`edit-gpt-name-${gpt.id}`}
+                                        value={editingGpt.name}
                                         onChange={(event) =>
-                                          updateEditingGpt((previous) => ({ ...previous, description: event.target.value }))
+                                          updateEditingGpt((previous) => ({ ...previous, name: event.target.value }))
                                         }
                                       />
                                     </div>
-                                    <div className="flex items-center justify-end gap-2">
-                                      <button
-                                        className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
-                                        onClick={() => setEditingGpt(null)}
-                                        type="button"
-                                      >
-                                        {t('options.cancelButton')}
-                                      </button>
-                                      <button
-                                        className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                                        type="submit"
-                                      >
-                                        {t('options.saveButton')}
-                                      </button>
+                                    <div className="space-y-2">
+                                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                                        {t('options.gptFolderSelectLabel')}
+                                      </p>
+                                      <div className="flex flex-wrap gap-3">
+                                        {createFolderBubbleItems(
+                                          gptFolderOptions,
+                                          editingGpt.folderId ?? '',
+                                          (folderId) =>
+                                            updateEditingGpt((previous) => ({ ...previous, folderId }))
+                                        )}
+                                      </div>
                                     </div>
-                                  </form>
-                                </td>
-                              </tr>
-                            ) : (
-                              <tr className="bg-slate-900/30">
-                                <td className="px-4 py-3">
-                                  <div className="flex flex-col">
-                                    <span className="font-medium text-slate-100">{gpt.name}</span>
-                                    {gpt.description ? (
-                                      <span className="text-xs text-slate-400">{truncate(gpt.description, 90)}</span>
-                                    ) : null}
                                   </div>
-                                </td>
-                                <td className="px-4 py-3 text-slate-300">
-                                  {gpt.folderId ? gptFolderNameById.get(gpt.folderId) ?? t('options.noneOption') : t('options.noneOption')}
-                                </td>
-                                <td className="px-4 py-3 text-slate-300">{formatNumber(promptCounts.get(gpt.id) ?? 0)}</td>
-                                <td className="px-4 py-3 text-slate-300">{formatDate(gpt.updatedAt)}</td>
-                                <td className="px-4 py-3 text-right">
-                                  <div className="flex justify-end gap-2">
-                                    <button
-                                      className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
-                                      onClick={() =>
-                                        setEditingGpt({
-                                          id: gpt.id,
-                                          name: gpt.name,
-                                          description: gpt.description ?? '',
-                                          folderId: gpt.folderId ?? ''
-                                        })
+                                  <div className="flex flex-col gap-2">
+                                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`edit-gpt-description-${gpt.id}`}>
+                                      {t('options.gptDescriptionLabel')}
+                                    </label>
+                                    <textarea
+                                      className="min-h-[80px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                                      id={`edit-gpt-description-${gpt.id}`}
+                                      value={editingGpt.description}
+                                      onChange={(event) =>
+                                        updateEditingGpt((previous) => ({ ...previous, description: event.target.value }))
                                       }
+                                    />
+                                  </div>
+                                  <div className="flex items-center justify-end gap-2">
+                                    <button
+                                      className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
+                                      onClick={() => setEditingGpt(null)}
                                       type="button"
                                     >
-                                      {t('options.editButton')}
+                                      {t('options.cancelButton')}
                                     </button>
                                     <button
-                                      className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
-                                      onClick={() => void removeGpt(gpt.id)}
-                                      type="button"
+                                      className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
+                                      type="submit"
                                     >
-                                      {t('options.deleteButton')}
+                                      {t('options.saveButton')}
                                     </button>
                                   </div>
-                                </td>
-                              </tr>
-                            )}
-                          </Fragment>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                </div>
+                                </form>
+                              </td>
+                            </tr>
+                          ) : (
+                            <tr className="bg-slate-900/30">
+                              <td className="px-4 py-3">
+                                <div className="flex flex-col">
+                                  <span className="font-medium text-slate-100">{gpt.name}</span>
+                                  {gpt.description ? (
+                                    <span className="text-xs text-slate-400">{truncate(gpt.description, 90)}</span>
+                                  ) : null}
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 text-slate-300">
+                                {gpt.folderId ? gptFolderNameById.get(gpt.folderId) ?? t('options.noneOption') : t('options.noneOption')}
+                              </td>
+                              <td className="px-4 py-3 text-slate-300">{formatNumber(promptCounts.get(gpt.id) ?? 0)}</td>
+                              <td className="px-4 py-3 text-slate-300">{formatDate(gpt.updatedAt)}</td>
+                              <td className="px-4 py-3 text-right">
+                                <div className="flex justify-end gap-2">
+                                  <button
+                                    className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+                                    onClick={() =>
+                                      setEditingGpt({
+                                        id: gpt.id,
+                                        name: gpt.name,
+                                        description: gpt.description ?? '',
+                                        folderId: gpt.folderId ?? ''
+                                      })
+                                    }
+                                    type="button"
+                                  >
+                                    {t('options.editButton')}
+                                  </button>
+                                  <button
+                                    className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
+                                    onClick={() => void removeGpt(gpt.id)}
+                                    type="button"
+                                  >
+                                    {t('options.deleteButton')}
+                                  </button>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
             </div>
           </TabPanel>
 
           <TabPanel value="prompts" labelledBy="prompt-panel">
-            <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
-              <aside>
-                <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-                  <header className="space-y-1">
-                    <h3 className="text-base font-semibold text-emerald-300">{t('options.promptFolderHeading')}</h3>
-                    <p className="text-xs text-slate-400">{t('options.promptFolderDescription')}</p>
-                  </header>
-                  <form className="flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); void createPromptFolder(); }}>
-                    <label className="text-xs font-medium uppercase tracking-wide text-slate-400" htmlFor="prompt-folder-name">
-                      {t('options.addFolder')}
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
-                        id="prompt-folder-name"
-                        placeholder={t('options.folderNamePlaceholder') ?? ''}
-                        value={promptFolderName}
-                        onChange={(event) => setPromptFolderName(event.target.value)}
-                      />
-                      <button
-                        className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                        type="submit"
-                      >
-                        {t('options.addFolderButton')}
-                      </button>
-                    </div>
-                  </form>
-                  <div className="space-y-2" role="tree" aria-label={t('options.promptFolderHeading')}>
-                    {renderPromptTree}
-                  </div>
-                </div>
-              </aside>
-              <div className="space-y-4">
-                <header>
+            <div className="space-y-6">
+              <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                <header className="space-y-1">
                   <h3 className="text-lg font-semibold text-emerald-300">{t('options.promptHeading')}</h3>
                   <p className="text-sm text-slate-300">{t('options.promptDescription')}</p>
                 </header>
-                <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-                  <form className="space-y-3" onSubmit={handleCreatePrompt}>
-                    <div className="grid gap-3 md:grid-cols-2">
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-name">
-                          {t('options.promptNameLabel')}
-                        </label>
-                        <input
-                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                          id="prompt-name"
-                          value={promptName}
-                          onChange={(event) => setPromptName(event.target.value)}
-                        />
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-gpt">
-                          {t('options.promptGptLabel')}
-                        </label>
-                        <select
-                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                          id="prompt-gpt"
-                          value={promptGptId}
-                          onChange={(event) => setPromptGptId(event.target.value)}
-                        >
-                          <option value="">{t('options.noneOption')}</option>
-                          {gpts.map((gpt) => (
-                            <option key={gpt.id} value={gpt.id}>
-                              {gpt.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                      {t('options.promptFolderSelectLabel')}
+                    </p>
+                    <p className="text-xs text-slate-500">{t('options.promptFolderDescription')}</p>
+                    <div className="flex flex-wrap gap-3">
+                      {createFolderBubbleItems(promptFolderOptions, promptFolderId, setPromptFolderId, true, deletePromptFolder)}
+                      <OptionBubble
+                        selected={showPromptFolderForm}
+                        aria-label={t('options.addFolder') ?? 'Add folder'}
+                        aria-expanded={showPromptFolderForm}
+                        onClick={() => setShowPromptFolderForm((previous) => !previous)}
+                      >
+                        +
+                      </OptionBubble>
                     </div>
-                    <div className="grid gap-3 md:grid-cols-2">
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-folder">
-                          {t('options.promptFolderSelectLabel')}
+                    {showPromptFolderForm ? (
+                      <form className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-3" onSubmit={handleCreatePromptFolder}>
+                        <label className="text-xs font-medium uppercase tracking-wide text-slate-400" htmlFor="prompt-folder-name">
+                          {t('options.addFolder')}
                         </label>
-                        <select
-                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                          id="prompt-folder"
-                          value={promptFolderId}
-                          onChange={(event) => setPromptFolderId(event.target.value)}
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                          <input
+                            className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+                            id="prompt-folder-name"
+                            placeholder={t('options.folderNamePlaceholder') ?? ''}
+                            value={promptFolderName}
+                            onChange={(event) => setPromptFolderName(event.target.value)}
+                          />
+                          <div className="flex gap-2 sm:w-auto">
+                            <button
+                              className="flex-1 rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 sm:flex-none"
+                              onClick={() => setShowPromptFolderForm(false)}
+                              type="button"
+                            >
+                              {t('options.cancelButton')}
+                            </button>
+                            <button
+                              className="flex-1 rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm sm:flex-none"
+                              type="submit"
+                            >
+                              {t('options.addFolderButton')}
+                            </button>
+                          </div>
+                        </div>
+                      </form>
+                    ) : null}
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                      {t('options.promptGptLabel')}
+                    </p>
+                    <div className="flex flex-wrap gap-3">
+                      {createGptBubbleItems(promptGptId, setPromptGptId)}
+                    </div>
+                    <p className="text-xs text-slate-500">
+                      {t('options.promptGptActiveLabel', { name: activePromptGptName })}
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                      {t('options.promptChainHeading')}
+                    </p>
+                    <div className="flex flex-wrap gap-3">
+                      {promptChains.map((chain) => (
+                        <OptionBubble
+                          key={chain.id}
+                          selected={editingPromptChain?.id === chain.id}
+                          onClick={() => {
+                            handleEditPromptChain(chain);
+                            setShowPromptChainManager(true);
+                          }}
+                          onRemove={() => void removePromptChain(chain.id)}
+                          removeLabel={t('options.promptChainRemoveButton') ?? undefined}
                         >
-                          <option value="">{t('options.noneOption')}</option>
-                          {promptFolderOptions.map((option) => (
-                            <option key={option.id} value={option.id}>
-                              {`${'— '.repeat(option.depth)}${option.name}`}
-                            </option>
-                          ))}
-                        </select>
+                          {chain.name}
+                        </OptionBubble>
+                      ))}
+                      <OptionBubble
+                        selected={showPromptChainManager && !editingPromptChain}
+                        aria-label={t('options.promptChainCreateButton')}
+                        aria-expanded={showPromptChainManager}
+                        onClick={() => {
+                          setShowPromptChainManager((previous) => {
+                            if (previous) {
+                              resetPromptChainForm();
+                            }
+                            return !previous;
+                          });
+                        }}
+                      >
+                        +
+                      </OptionBubble>
+                    </div>
+                    <p className="text-xs text-slate-500">{t('options.promptChainBubbleHelper')}</p>
+                  </div>
+                  {showPromptChainManager ? (
+                    <div className="space-y-4 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <h4 className="text-base font-semibold text-slate-100">
+                            {editingPromptChain
+                              ? t('options.promptChainEditTitle', { name: editingPromptChain?.name ?? '' })
+                              : t('options.promptChainBuilderHeading')}
+                          </h4>
+                          <p className="text-xs text-slate-400">{t('options.promptChainHelper')}</p>
+                        </div>
+                        <button
+                          className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+                          onClick={() => {
+                            setShowPromptChainManager(false);
+                            resetPromptChainForm();
+                          }}
+                          type="button"
+                        >
+                          {t('options.cancelButton')}
+                        </button>
                       </div>
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-description">
-                          {t('options.promptDescriptionLabel')}
-                        </label>
-                        <input
-                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                          id="prompt-description"
-                          value={promptDescription}
-                          onChange={(event) => setPromptDescription(event.target.value)}
-                        />
-                      </div>
+                      <form className="space-y-4" onSubmit={handleSavePromptChain}>
+                        <div className="flex flex-col gap-2">
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-chain-name">
+                            {t('options.promptChainNameLabel')}
+                          </label>
+                          <input
+                            className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                            id="prompt-chain-name"
+                            placeholder={t('options.promptChainNamePlaceholder') ?? ''}
+                            value={promptChainName}
+                            onChange={(event) => setPromptChainName(event.target.value)}
+                          />
+                        </div>
+                        <div className="grid gap-4 lg:grid-cols-2">
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-semibold text-slate-100">{t('options.promptChainAvailableHeading')}</h4>
+                            <p className="text-xs text-slate-400">{t('options.promptChainAvailableDescription')}</p>
+                            {availableChainPrompts.length === 0 ? (
+                              <EmptyState title={t('options.promptChainAvailableEmpty')} align="start" className="px-4 py-6 text-sm" />
+                            ) : (
+                              <ul className="space-y-2">
+                                {availableChainPrompts.map((prompt) => (
+                                  <li key={prompt.id} className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2">
+                                    <span className="text-sm text-slate-100">{prompt.name}</span>
+                                    <button
+                                      className="rounded-md border border-emerald-500 px-3 py-1 text-xs uppercase tracking-wide text-emerald-300 hover:bg-emerald-500/10"
+                                      onClick={() => addPromptToChain(prompt.id)}
+                                      type="button"
+                                    >
+                                      {t('options.promptChainAddButton')}
+                                    </button>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-semibold text-slate-100">{t('options.promptChainStepsHeading')}</h4>
+                            <p className="text-xs text-slate-400">{t('options.promptChainStepsDescription')}</p>
+                            {selectedChainPrompts.length === 0 ? (
+                              <EmptyState title={t('options.promptChainSelectedEmpty')} align="start" className="px-4 py-6 text-sm" />
+                            ) : (
+                              <ol className="space-y-2">
+                                {selectedChainPrompts.map((prompt, index) => (
+                                  <li key={prompt.id} className="rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2">
+                                    <div className="flex items-start justify-between gap-3">
+                                      <div>
+                                        <p className="text-sm font-semibold text-slate-100">
+                                          {t('options.promptChainStepLabel', { index: index + 1 })}
+                                        </p>
+                                        <p className="text-xs text-slate-400">{prompt.name}</p>
+                                      </div>
+                                      <div className="flex flex-col gap-2">
+                                        <button
+                                          aria-label={t('options.promptChainMoveUp') ?? 'Move up'}
+                                          className="rounded-md border border-slate-700 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-200"
+                                          onClick={() => movePromptInChain(prompt.id, 'up')}
+                                          type="button"
+                                        >
+                                          {t('options.promptChainMoveUp')}
+                                        </button>
+                                        <button
+                                          aria-label={t('options.promptChainMoveDown') ?? 'Move down'}
+                                          className="rounded-md border border-slate-700 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-200"
+                                          onClick={() => movePromptInChain(prompt.id, 'down')}
+                                          type="button"
+                                        >
+                                          {t('options.promptChainMoveDown')}
+                                        </button>
+                                        <button
+                                          className="rounded-md border border-rose-600 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-rose-300"
+                                          onClick={() => removePromptFromChain(prompt.id)}
+                                          type="button"
+                                        >
+                                          {t('options.promptChainRemoveButton')}
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </li>
+                                ))}
+                              </ol>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center justify-end gap-2">
+                          <button
+                            className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
+                            onClick={() => {
+                              resetPromptChainForm();
+                              setShowPromptChainManager(false);
+                            }}
+                            type="button"
+                          >
+                            {t('options.cancelButton')}
+                          </button>
+                          <button
+                            className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
+                            type="submit"
+                          >
+                            {editingPromptChain ? t('options.promptChainUpdateButton') : t('options.promptChainCreateButton')}
+                          </button>
+                        </div>
+                      </form>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+              <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                <header className="space-y-1">
+                  <h3 className="text-base font-semibold text-emerald-200">{t('options.promptFormHeading')}</h3>
+                  <p className="text-xs text-slate-400">{t('options.promptFormDescription')}</p>
+                </header>
+                <form className="space-y-4" onSubmit={handleCreatePrompt}>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="flex flex-col gap-2">
+                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-name">
+                        {t('options.promptNameLabel')}
+                      </label>
+                      <input
+                        className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                        id="prompt-name"
+                        value={promptName}
+                        onChange={(event) => setPromptName(event.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                        {t('options.promptFolderActiveLabel')}
+                      </p>
+                      <span className="inline-flex min-h-[32px] items-center rounded-full border border-slate-700 px-4 text-sm text-slate-200">
+                        {activePromptFolderName}
+                      </span>
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                        {t('options.promptGptActiveLabel')}
+                      </p>
+                      <span className="inline-flex min-h-[32px] items-center rounded-full border border-slate-700 px-4 text-sm text-slate-200">
+                        {activePromptGptName}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="flex flex-col gap-2">
+                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-description">
+                        {t('options.promptDescriptionLabel')}
+                      </label>
+                      <textarea
+                        className="min-h-[80px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                        id="prompt-description"
+                        value={promptDescription}
+                        onChange={(event) => setPromptDescription(event.target.value)}
+                      />
                     </div>
                     <div className="flex flex-col gap-2">
                       <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-content">
@@ -534,353 +780,180 @@ export function PromptsSection() {
                         onChange={(event) => setPromptContent(event.target.value)}
                       />
                     </div>
-                    <button
-                      className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                      type="submit"
-                    >
-                      {t('options.createButton')}
-                    </button>
-                  </form>
-                </div>
-                <div className="overflow-hidden rounded-xl border border-slate-800">
-                  <table className="min-w-full divide-y divide-slate-800 text-sm">
-                    <thead className="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-400">
+                  </div>
+                  <button
+                    className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
+                    type="submit"
+                  >
+                    {t('options.promptCreateButton')}
+                  </button>
+                </form>
+              </div>
+              <div className="overflow-hidden rounded-xl border border-slate-800">
+                <table className="min-w-full divide-y divide-slate-800 text-sm">
+                  <thead className="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-400">
+                    <tr>
+                      <th className="px-4 py-3">{t('options.promptTableName')}</th>
+                      <th className="px-4 py-3">{t('options.promptTableGpt')}</th>
+                      <th className="px-4 py-3">{t('options.promptTableFolder')}</th>
+                      <th className="px-4 py-3">{t('options.columnUpdated')}</th>
+                      <th className="px-4 py-3 text-right">{t('options.columnActions')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-900/60">
+                    {prompts.length === 0 ? (
                       <tr>
-                        <th className="px-4 py-3">{t('options.columnTitle')}</th>
-                        <th className="px-4 py-3">{t('options.promptFolderColumn')}</th>
-                        <th className="px-4 py-3">{t('options.promptGptColumn')}</th>
-                        <th className="px-4 py-3">{t('options.columnUpdated')}</th>
-                        <th className="px-4 py-3 text-right">{t('options.columnActions')}</th>
+                        <td className="px-4 py-6" colSpan={5}>
+                          <EmptyState title={t('options.promptEmpty')} align="start" className="py-8" />
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody className="divide-y divide-slate-900/60">
-                      {prompts.length === 0 ? (
-                        <tr>
-                          <td className="px-4 py-6" colSpan={5}>
-                            <EmptyState title={t('options.promptEmpty')} align="start" className="py-8" />
-                          </td>
-                        </tr>
-                      ) : (
-                        prompts.map((prompt) => (
-                          <Fragment key={prompt.id}>
-                            {editingPrompt?.id === prompt.id ? (
-                              <tr className="bg-slate-900/40">
-                                <td colSpan={5} className="px-4 py-3">
-                                  <form className="space-y-3" onSubmit={handleSavePrompt}>
-                                    <div className="grid gap-3 md:grid-cols-2">
-                                      <div className="flex flex-col gap-2">
-                                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-prompt-name">
-                                          {t('options.promptNameLabel')}
-                                        </label>
-                                        <input
-                                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                          id="edit-prompt-name"
-                                          value={editingPrompt.name}
-                                          onChange={(event) =>
-                                            updateEditingPrompt((previous) => ({ ...previous, name: event.target.value }))
-                                          }
-                                        />
-                                      </div>
-                                      <div className="flex flex-col gap-2">
-                                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-prompt-gpt">
-                                          {t('options.promptGptLabel')}
-                                        </label>
-                                        <select
-                                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                          id="edit-prompt-gpt"
-                                          value={editingPrompt.gptId}
-                                          onChange={(event) =>
-                                            updateEditingPrompt((previous) => ({ ...previous, gptId: event.target.value }))
-                                          }
-                                        >
-                                          <option value="">{t('options.noneOption')}</option>
-                                          {gpts.map((gpt) => (
-                                            <option key={gpt.id} value={gpt.id}>
-                                              {gpt.name}
-                                            </option>
-                                          ))}
-                                        </select>
+                    ) : (
+                      prompts.map((prompt) => (
+                        <Fragment key={prompt.id}>
+                          {editingPrompt?.id === prompt.id ? (
+                            <tr className="bg-slate-900/40">
+                              <td colSpan={5} className="px-4 py-3">
+                                <form className="space-y-4" onSubmit={handleSavePrompt}>
+                                  <div className="grid gap-3 md:grid-cols-2">
+                                    <div className="flex flex-col gap-2">
+                                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`edit-prompt-name-${prompt.id}`}>
+                                        {t('options.promptNameLabel')}
+                                      </label>
+                                      <input
+                                        className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                                        id={`edit-prompt-name-${prompt.id}`}
+                                        value={editingPrompt.name}
+                                        onChange={(event) =>
+                                          updateEditingPrompt((previous) => ({ ...previous, name: event.target.value }))
+                                        }
+                                      />
+                                    </div>
+                                    <div className="space-y-2">
+                                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                                        {t('options.promptGptLabel')}
+                                      </p>
+                                      <div className="flex flex-wrap gap-3">
+                                        {createGptBubbleItems(
+                                          editingPrompt.gptId ?? '',
+                                          (gptId) => updateEditingPrompt((previous) => ({ ...previous, gptId }))
+                                        )}
                                       </div>
                                     </div>
-                                    <div className="grid gap-3 md:grid-cols-2">
-                                      <div className="flex flex-col gap-2">
-                                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-prompt-folder">
-                                          {t('options.promptFolderSelectLabel')}
-                                        </label>
-                                        <select
-                                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                          id="edit-prompt-folder"
-                                          value={editingPrompt.folderId}
-                                          onChange={(event) =>
-                                            updateEditingPrompt((previous) => ({ ...previous, folderId: event.target.value }))
-                                          }
-                                        >
-                                          <option value="">{t('options.noneOption')}</option>
-                                          {promptFolderOptions.map((option) => (
-                                            <option key={option.id} value={option.id}>
-                                              {`${'— '.repeat(option.depth)}${option.name}`}
-                                            </option>
-                                          ))}
-                                        </select>
-                                      </div>
-                                      <div className="flex flex-col gap-2">
-                                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-prompt-description">
-                                          {t('options.promptDescriptionLabel')}
-                                        </label>
-                                        <input
-                                          className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                          id="edit-prompt-description"
-                                          value={editingPrompt.description}
-                                          onChange={(event) =>
-                                            updateEditingPrompt((previous) => ({ ...previous, description: event.target.value }))
-                                          }
-                                        />
-                                      </div>
+                                  </div>
+                                  <div className="space-y-2">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                                      {t('options.promptFolderSelectLabel')}
+                                    </p>
+                                    <div className="flex flex-wrap gap-3">
+                                      {createFolderBubbleItems(
+                                        promptFolderOptions,
+                                        editingPrompt.folderId ?? '',
+                                        (folderId) => updateEditingPrompt((previous) => ({ ...previous, folderId }))
+                                      )}
+                                    </div>
+                                  </div>
+                                  <div className="grid gap-3 md:grid-cols-2">
+                                    <div className="flex flex-col gap-2">
+                                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`edit-prompt-description-${prompt.id}`}>
+                                        {t('options.promptDescriptionLabel')}
+                                      </label>
+                                      <textarea
+                                        className="min-h-[80px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                                        id={`edit-prompt-description-${prompt.id}`}
+                                        value={editingPrompt.description}
+                                        onChange={(event) =>
+                                          updateEditingPrompt((previous) => ({ ...previous, description: event.target.value }))
+                                        }
+                                      />
                                     </div>
                                     <div className="flex flex-col gap-2">
-                                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="edit-prompt-content">
+                                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`edit-prompt-content-${prompt.id}`}>
                                         {t('options.promptContentLabel')}
                                       </label>
                                       <textarea
                                         className="min-h-[120px] rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                                        id="edit-prompt-content"
+                                        id={`edit-prompt-content-${prompt.id}`}
                                         value={editingPrompt.content}
                                         onChange={(event) =>
                                           updateEditingPrompt((previous) => ({ ...previous, content: event.target.value }))
                                         }
                                       />
                                     </div>
-                                    <div className="flex items-center justify-end gap-2">
-                                      <button
-                                        className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
-                                        onClick={() => setEditingPrompt(null)}
-                                        type="button"
-                                      >
-                                        {t('options.cancelButton')}
-                                      </button>
-                                      <button
-                                        className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                                        type="submit"
-                                      >
-                                        {t('options.saveButton')}
-                                      </button>
-                                    </div>
-                                  </form>
-                                </td>
-                              </tr>
-                            ) : (
-                              <tr className="bg-slate-900/30">
-                                <td className="px-4 py-3">
-                                  <div className="flex flex-col">
-                                    <span className="font-medium text-slate-100">{prompt.name}</span>
-                                    {prompt.description ? (
-                                      <span className="text-xs text-slate-400">{truncate(prompt.description, 90)}</span>
-                                    ) : null}
                                   </div>
-                                </td>
-                                <td className="px-4 py-3 text-slate-300">
-                                  {prompt.folderId ? promptFolderNameById.get(prompt.folderId) ?? t('options.noneOption') : t('options.noneOption')}
-                                </td>
-                                <td className="px-4 py-3 text-slate-300">
-                                  {prompt.gptId ? gptById.get(prompt.gptId)?.name ?? t('options.noneOption') : t('options.noneOption')}
-                                </td>
-                                <td className="px-4 py-3 text-slate-300">{formatDate(prompt.updatedAt)}</td>
-                                <td className="px-4 py-3 text-right">
-                                  <div className="flex justify-end gap-2">
+                                  <div className="flex items-center justify-end gap-2">
                                     <button
-                                      className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
-                                      onClick={() =>
-                                        setEditingPrompt({
-                                          id: prompt.id,
-                                          name: prompt.name,
-                                          description: prompt.description ?? '',
-                                          content: prompt.content,
-                                          folderId: prompt.folderId ?? '',
-                                          gptId: prompt.gptId ?? ''
-                                        })
-                                      }
+                                      className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
+                                      onClick={() => setEditingPrompt(null)}
                                       type="button"
                                     >
-                                      {t('options.editButton')}
+                                      {t('options.cancelButton')}
                                     </button>
                                     <button
-                                      className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
-                                      onClick={() => void removePrompt(prompt.id)}
-                                      type="button"
+                                      className="rounded-md bg-emerald-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
+                                      type="submit"
                                     >
-                                      {t('options.deleteButton')}
+                                      {t('options.saveButton')}
                                     </button>
                                   </div>
-                                </td>
-                              </tr>
-                            )}
-                          </Fragment>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                </div>
+                                </form>
+                              </td>
+                            </tr>
+                          ) : (
+                            <tr className="bg-slate-900/30">
+                              <td className="px-4 py-3">
+                                <div className="flex flex-col">
+                                  <span className="font-medium text-slate-100">{prompt.name}</span>
+                                  {prompt.description ? (
+                                    <span className="text-xs text-slate-400">{truncate(prompt.description, 90)}</span>
+                                  ) : null}
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 text-slate-300">
+                                {prompt.gptId ? gptById.get(prompt.gptId)?.name ?? t('options.noneOption') : t('options.noneOption')}
+                              </td>
+                              <td className="px-4 py-3 text-slate-300">
+                                {prompt.folderId ? promptFolderNameById.get(prompt.folderId) ?? t('options.noneOption') : t('options.noneOption')}
+                              </td>
+                              <td className="px-4 py-3 text-slate-300">{formatDate(prompt.updatedAt)}</td>
+                              <td className="px-4 py-3 text-right">
+                                <div className="flex justify-end gap-2">
+                                  <button
+                                    className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+                                    onClick={() =>
+                                      setEditingPrompt({
+                                        id: prompt.id,
+                                        name: prompt.name,
+                                        description: prompt.description ?? '',
+                                        content: prompt.content,
+                                        folderId: prompt.folderId ?? '',
+                                        gptId: prompt.gptId ?? ''
+                                      })
+                                    }
+                                    type="button"
+                                  >
+                                    {t('options.editButton')}
+                                  </button>
+                                  <button
+                                    className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
+                                    onClick={() => void removePrompt(prompt.id)}
+                                    type="button"
+                                  >
+                                    {t('options.deleteButton')}
+                                  </button>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
             </div>
           </TabPanel>
 
-          <TabPanel value="chains" labelledBy="chain-panel">
-            <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
-              <aside className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-                <header className="space-y-1">
-                  <h3 className="text-base font-semibold text-emerald-300">{t('options.promptChainListHeading')}</h3>
-                  <p className="text-xs text-slate-400">{t('options.promptChainListDescription')}</p>
-                </header>
-                {promptChains.length === 0 ? (
-                  <EmptyState title={t('options.promptChainEmpty')} align="start" className="px-4 py-6 text-sm" />
-                ) : (
-                  <ul className="space-y-3">
-                    {promptChains.map((chain) => (
-                      <li
-                        key={chain.id}
-                        className="rounded-lg border border-slate-800 bg-slate-900/50 p-3"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <p className="text-sm font-semibold text-slate-100">{chain.name}</p>
-                            <p className="text-xs text-slate-400">
-                              {t('options.promptChainPromptCount', { count: chain.nodeIds.length })}
-                            </p>
-                          </div>
-                          <div className="flex gap-2">
-                            <button
-                              className="rounded-md border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
-                              onClick={() => handleEditPromptChain(chain)}
-                              type="button"
-                            >
-                              {t('options.editButton')}
-                            </button>
-                            <button
-                              className="rounded-md border border-rose-600 px-3 py-1 text-xs uppercase tracking-wide text-rose-300 hover:bg-rose-600/20"
-                              onClick={() => void removePromptChain(chain.id)}
-                              type="button"
-                            >
-                              {t('options.deleteButton')}
-                            </button>
-                          </div>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </aside>
-              <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-                <header className="space-y-1">
-                  <h3 className="text-base font-semibold text-slate-100">
-                    {editingPromptChain
-                      ? t('options.promptChainEditTitle', { name: editingPromptChain?.name ?? '' })
-                      : t('options.promptChainBuilderHeading')}
-                  </h3>
-                  <p className="text-xs text-slate-400">{t('options.promptChainHelper')}</p>
-                </header>
-                <form className="space-y-4" onSubmit={handleSavePromptChain}>
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="prompt-chain-name">
-                      {t('options.promptChainNameLabel')}
-                    </label>
-                    <input
-                      className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
-                      id="prompt-chain-name"
-                      placeholder={t('options.promptChainNamePlaceholder') ?? ''}
-                      value={promptChainName}
-                      onChange={(event) => setPromptChainName(event.target.value)}
-                    />
-                  </div>
-                  <div className="grid gap-4 lg:grid-cols-2">
-                    <div className="space-y-2">
-                      <h4 className="text-sm font-semibold text-slate-100">{t('options.promptChainAvailableHeading')}</h4>
-                      <p className="text-xs text-slate-400">{t('options.promptChainAvailableDescription')}</p>
-                      {availableChainPrompts.length === 0 ? (
-                        <EmptyState title={t('options.promptChainAvailableEmpty')} align="start" className="px-4 py-6 text-sm" />
-                      ) : (
-                        <ul className="space-y-2">
-                          {availableChainPrompts.map((prompt) => (
-                            <li key={prompt.id} className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2">
-                              <span className="text-sm text-slate-100">{prompt.name}</span>
-                              <button
-                                className="rounded-md border border-emerald-500 px-3 py-1 text-xs uppercase tracking-wide text-emerald-300 hover:bg-emerald-500/10"
-                                onClick={() => addPromptToChain(prompt.id)}
-                                type="button"
-                              >
-                                {t('options.promptChainAddButton')}
-                              </button>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                    </div>
-                    <div className="space-y-2">
-                      <h4 className="text-sm font-semibold text-slate-100">{t('options.promptChainStepsHeading')}</h4>
-                      <p className="text-xs text-slate-400">{t('options.promptChainStepsDescription')}</p>
-                      {selectedChainPrompts.length === 0 ? (
-                        <EmptyState title={t('options.promptChainSelectedEmpty')} align="start" className="px-4 py-6 text-sm" />
-                      ) : (
-                        <ol className="space-y-2">
-                          {selectedChainPrompts.map((prompt, index) => (
-                            <li key={prompt.id} className="rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2">
-                              <div className="flex items-start justify-between gap-3">
-                                <div>
-                                  <p className="text-sm font-semibold text-slate-100">
-                                    {t('options.promptChainStepLabel', { index: index + 1 })}
-                                  </p>
-                                  <p className="text-xs text-slate-400">{prompt.name}</p>
-                                </div>
-                                <div className="flex flex-col gap-2">
-                                  <button
-                                    aria-label={t('options.promptChainMoveUp') ?? 'Move up'}
-                                    className="rounded-md border border-slate-700 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-200"
-                                    onClick={() => movePromptInChain(prompt.id, 'up')}
-                                    type="button"
-                                  >
-                                    {t('options.promptChainMoveUp')}
-                                  </button>
-                                  <button
-                                    aria-label={t('options.promptChainMoveDown') ?? 'Move down'}
-                                    className="rounded-md border border-slate-700 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-200"
-                                    onClick={() => movePromptInChain(prompt.id, 'down')}
-                                    type="button"
-                                  >
-                                    {t('options.promptChainMoveDown')}
-                                  </button>
-                                  <button
-                                    className="rounded-md border border-rose-600 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-rose-300"
-                                    onClick={() => removePromptFromChain(prompt.id)}
-                                    type="button"
-                                  >
-                                    {t('options.promptChainRemoveButton')}
-                                  </button>
-                                </div>
-                              </div>
-                            </li>
-                          ))}
-                        </ol>
-                      )}
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between gap-3">
-                    <button
-                      className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200"
-                      onClick={resetPromptChainForm}
-                      type="button"
-                    >
-                      {t('options.cancelButton')}
-                    </button>
-                    <button
-                      className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-sm"
-                      type="submit"
-                    >
-                      {editingPromptChain ? t('options.promptChainUpdateButton') : t('options.promptChainCreateButton')}
-                    </button>
-                  </div>
-                </form>
-              </div>
-            </div>
-          </TabPanel>
+
         </TabPanels>
       </Tabs>
     </section>

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -88,7 +88,7 @@
     "conversationEmpty": "No conversations captured yet.",
     "conversationFilteredEmpty": "No conversations match the current filters.",
     "conversationFiltersHeading": "Filters & sorting",
-    "conversationFiltersDescription": "Adjust folders, pin state, archive status, and sort order.",
+    "conversationFiltersDescription": "Toggle filters with the bubbles to adjust folders, pin state, archive status, and sort order.",
     "filterFolderLabel": "Folder filter",
     "filterFolderAll": "All folders",
     "filterPinnedLabel": "Pinned",
@@ -134,7 +134,7 @@
     "columnActions": "Actions",
     "untitledConversation": "Untitled conversation",
     "gptFolderHeading": "GPT folders",
-    "gptFolderDescription": "Group custom GPTs by workflow or domain.",
+    "gptFolderDescription": "Pick, remove, or add GPT folders with the bubbles. The active choice applies to new entries.",
     "gptHeading": "Custom GPT library",
     "gptDescription": "Catalog reusable GPT configurations with descriptions and folders.",
     "gptNameLabel": "Name",
@@ -147,7 +147,7 @@
     "gptTablePrompts": "Prompts",
     "gptEmpty": "No custom GPTs yet.",
     "promptFolderHeading": "Prompt folders",
-    "promptFolderDescription": "Organize reusable templates by team or project.",
+    "promptFolderDescription": "Use the bubbles to choose where prompts live and to create or remove folders.",
     "promptHeading": "Prompt templates",
     "promptDescription": "Draft and store reusable prompt snippets. Link them to GPTs for quick sequencing.",
     "promptNameLabel": "Title",
@@ -192,7 +192,13 @@
     "sidebarToggleLabel": "Sidebar visibility",
     "sidebarToggleHelp": "Toggle the floating sidebar in the ChatGPT interface.",
     "sidebarToggleOn": "Enabled",
-    "sidebarToggleOff": "Disabled"
+    "sidebarToggleOff": "Disabled",
+    "gptFolderActiveLabel": "Active folder: {{name}}",
+    "promptFolderActiveLabel": "Active folder: {{name}}",
+    "promptGptActiveLabel": "Linked GPT: {{name}}",
+    "promptFormHeading": "Create prompt template",
+    "promptFormDescription": "Your folder, GPT link, and chains follow the bubble selections above.",
+    "promptChainBubbleHelper": "Select an existing chain to edit or tap + to start a new sequence."
   },
   "content": {
     "sidebar": {

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -88,7 +88,7 @@
     "conversationEmpty": "Nog geen gesprekken vastgelegd.",
     "conversationFilteredEmpty": "Geen gesprekken komen overeen met de huidige filters.",
     "conversationFiltersHeading": "Filters & sortering",
-    "conversationFiltersDescription": "Stel map-, pin- en archiefstatus en sorteervolgorde in.",
+    "conversationFiltersDescription": "Gebruik de bubbels om map-, pin- en archiefstatus en sorteervolgorde aan te passen.",
     "filterFolderLabel": "Mapfilter",
     "filterFolderAll": "Alle mappen",
     "filterPinnedLabel": "Vastgezet",
@@ -134,7 +134,7 @@
     "columnActions": "Acties",
     "untitledConversation": "Naamloos gesprek",
     "gptFolderHeading": "GPT-mappen",
-    "gptFolderDescription": "Groepeer aangepaste GPT's per workflow of domein.",
+    "gptFolderDescription": "Gebruik de bubbels om GPT-mappen te kiezen, te verwijderen of toe te voegen. De actieve map wordt toegepast op nieuwe items.",
     "gptHeading": "Bibliotheek met aangepaste GPT's",
     "gptDescription": "Leg herbruikbare GPT-configuraties vast met beschrijving en map.",
     "gptNameLabel": "Naam",
@@ -147,7 +147,7 @@
     "gptTablePrompts": "Prompts",
     "gptEmpty": "Nog geen aangepaste GPT's.",
     "promptFolderHeading": "Promptmappen",
-    "promptFolderDescription": "Organiseer sjablonen per team of project.",
+    "promptFolderDescription": "Kies via de bubbels waar prompts terechtkomen en beheer hier nieuwe of verwijderde mappen.",
     "promptHeading": "Promptsjablonen",
     "promptDescription": "Schrijf en bewaar herbruikbare promptsnippers. Koppel ze aan GPT's voor snelle workflows.",
     "promptNameLabel": "Titel",
@@ -192,7 +192,13 @@
     "sidebarToggleLabel": "Zijbalkweergave",
     "sidebarToggleHelp": "Schakel de zwevende zijbalk in de ChatGPT-interface in of uit.",
     "sidebarToggleOn": "Ingeschakeld",
-    "sidebarToggleOff": "Uitgeschakeld"
+    "sidebarToggleOff": "Uitgeschakeld",
+    "gptFolderActiveLabel": "Actieve map: {{name}}",
+    "promptFolderActiveLabel": "Actieve map: {{name}}",
+    "promptGptActiveLabel": "Gekoppelde GPT: {{name}}",
+    "promptFormHeading": "Promptsjabloon maken",
+    "promptFormDescription": "Je map, GPT-koppeling en ketens volgen de bubbelselecties hierboven.",
+    "promptChainBubbleHelper": "Selecteer een bestaande keten om te bewerken of tik op + om een nieuwe reeks te starten."
   },
   "content": {
     "sidebar": {


### PR DESCRIPTION
## Summary
- replace the folder tree UI with a reusable OptionBubble component and helper utilities
- restyle history filters and prompt management tabs with bubble groups and inline forms
- update English and Dutch copy to explain the new bubble interactions

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17a568f1c83339f57bb33f26e2fcf