### PR TITLE
feat: expand bubble dock scaffolding

### DIFF
--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -214,6 +214,43 @@
     "promptChainBubbleHelper": "Select an existing chain to edit or tap + to start a new sequence."
   },
   "content": {
+    "dock": {
+      "prompts": "Prompts ({{count}})",
+      "promptsAria": "Toggle prompts bubble ({{count}} available)",
+      "bookmarks": "Bookmarks",
+      "bookmarksAria": "Open bookmark bubble",
+      "pinned": "Pinned",
+      "pinnedAria": "Open pinned bubble",
+      "actions": "Actions",
+      "actionsAria": "Open actions bubble",
+      "settings": "Settings",
+      "settingsAria": "Open settings bubble",
+      "dashboard": "Dashboard",
+      "dashboardAria": "Open dashboard",
+      "closePanelAria": "Close bubble panel"
+    },
+    "bubblePanels": {
+      "bookmarks": {
+        "title": "Conversation bookmarks",
+        "placeholderTitle": "Bookmark tools are almost here",
+        "placeholderSubtitle": "Soon you'll capture messages, add notes, and sync them across popup and dashboard from this bubble."
+      },
+      "pinned": {
+        "title": "Pinned conversations",
+        "placeholderTitle": "Quick pin controls on the way",
+        "placeholderSubtitle": "Manage pins and favorite folders without leaving ChatGPT once this bubble unlocks."
+      },
+      "actions": {
+        "title": "Actions & shortcuts",
+        "placeholderTitle": "Contextual actions arriving shortly",
+        "placeholderSubtitle": "This bubble will soon bundle quick operations like bookmarking, exporting, and sharing."
+      },
+      "settings": {
+        "title": "Settings",
+        "placeholderTitle": "Adjust the Companion without leaving the chat",
+        "placeholderSubtitle": "Dock visibility, direction, and audio toggles will land in this bubble soon."
+      }
+    },
     "sidebar": {
       "title": "AI Companion",
       "patternButton": "Patterns",

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -214,6 +214,43 @@
     "promptChainBubbleHelper": "Selecteer een bestaande keten om te bewerken of tik op + om een nieuwe reeks te starten."
   },
   "content": {
+    "dock": {
+      "prompts": "Prompts ({{count}})",
+      "promptsAria": "Prompt-bubbel openen ({{count}} beschikbaar)",
+      "bookmarks": "Bladwijzers",
+      "bookmarksAria": "Bladwijzerbubbel openen",
+      "pinned": "Vastgezet",
+      "pinnedAria": "Vastgezette bubbel openen",
+      "actions": "Acties",
+      "actionsAria": "Actiebubbel openen",
+      "settings": "Instellingen",
+      "settingsAria": "Instellingenbubbel openen",
+      "dashboard": "Dashboard",
+      "dashboardAria": "Dashboard openen",
+      "closePanelAria": "Bubbelpaneel sluiten"
+    },
+    "bubblePanels": {
+      "bookmarks": {
+        "title": "Gespreksbladwijzers",
+        "placeholderTitle": "Bladwijzerhulpmiddelen zijn bijna klaar",
+        "placeholderSubtitle": "Binnenkort kun je hier berichten bewaren, notities toevoegen en synchroniseren met popup en dashboard."
+      },
+      "pinned": {
+        "title": "Vastgezette gesprekken",
+        "placeholderTitle": "Snel pinbeheer is onderweg",
+        "placeholderSubtitle": "Beheer straks pins en favoriete mappen rechtstreeks vanuit de chat zodra deze bubbel actief is."
+      },
+      "actions": {
+        "title": "Acties & snelkoppelingen",
+        "placeholderTitle": "Contextuele acties verschijnen snel",
+        "placeholderSubtitle": "Deze bubbel bundelt binnenkort snelle bewerkingen zoals bookmarken, exporteren en delen."
+      },
+      "settings": {
+        "title": "Instellingen",
+        "placeholderTitle": "Pas de Companion aan zonder de chat te verlaten",
+        "placeholderSubtitle": "Dock-weergave, richting en audio-instellingen komen binnenkort in deze bubbel beschikbaar."
+      }
+    },
     "sidebar": {
       "title": "AI Companion",
       "patternButton": "Patronen",


### PR DESCRIPTION
## Summary
- restructure the content bubble dock around reusable bubble configurations with placeholder panels
- add resilient event helpers so the dock can mount in environments without shadow DOM support
- localize the new bubble menu labels and placeholders in both English and Dutch

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1fcf85ee48333a6beae8766a25c63