### PR TITLE
feat: surface live bookmarks in launcher

### DIFF
--- a/retrofit.md
+++ b/retrofit.md
@@ -160,6 +160,6 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | Datum | Commit | Featuregroep(en) | Opmerkingen |
 | --- | --- | --- | --- |
 | 2025-10-05 | _pending_ | Conversatiedock; pin/verplaats | Dexie v6 favoriete mappen + MoveDialog toegevoegd; lint uitgevoerd |
-| 2025-10-05 | _pending_ | Bladwijzers & contextmenu | Bookmark previews opgeslagen in Dexie; lint/test/build uitgevoerd |
+| 2025-10-05 | _pending_ | Bladwijzers & contextmenu | Bookmarkbubble toont live Dexie-data + notities; lint/test/build uitgevoerd |
 | _vul in_ | _vul in_ | _vul in_ | _korte notitie over tests, regressies, follow-up_ |
 

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -217,8 +217,8 @@
     "dock": {
       "prompts": "Prompts ({{count}})",
       "promptsAria": "Toggle prompts bubble ({{count}} available)",
-      "bookmarks": "Bookmarks",
-      "bookmarksAria": "Open bookmark bubble",
+      "bookmarks": "Bookmarks ({{count}})",
+      "bookmarksAria": "Open bookmark bubble ({{count}} available)",
       "pinned": "Pinned",
       "pinnedAria": "Open pinned bubble",
       "actions": "Actions",
@@ -232,8 +232,8 @@
     "bubblePanels": {
       "bookmarks": {
         "title": "Conversation bookmarks",
-        "placeholderTitle": "Bookmark tools are almost here",
-        "placeholderSubtitle": "Soon you'll capture messages, add notes, and sync them across popup and dashboard from this bubble."
+        "emptyTitle": "No bookmarks yet",
+        "emptySubtitle": "Bookmark ChatGPT messages to keep quick references handy in this bubble."
       },
       "pinned": {
         "title": "Pinned conversations",

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -217,8 +217,8 @@
     "dock": {
       "prompts": "Prompts ({{count}})",
       "promptsAria": "Prompt-bubbel openen ({{count}} beschikbaar)",
-      "bookmarks": "Bladwijzers",
-      "bookmarksAria": "Bladwijzerbubbel openen",
+      "bookmarks": "Bladwijzers ({{count}})",
+      "bookmarksAria": "Bladwijzerbubbel openen ({{count}} beschikbaar)",
       "pinned": "Vastgezet",
       "pinnedAria": "Vastgezette bubbel openen",
       "actions": "Acties",
@@ -232,8 +232,8 @@
     "bubblePanels": {
       "bookmarks": {
         "title": "Gespreksbladwijzers",
-        "placeholderTitle": "Bladwijzerhulpmiddelen zijn bijna klaar",
-        "placeholderSubtitle": "Binnenkort kun je hier berichten bewaren, notities toevoegen en synchroniseren met popup en dashboard."
+        "emptyTitle": "Nog geen bladwijzers",
+        "emptySubtitle": "Maak bladwijzers van ChatGPT-berichten om ze hier snel terug te vinden."
       },
       "pinned": {
         "title": "Vastgezette gesprekken",


### PR DESCRIPTION
## Summary
- wire the bookmarks bubble in the content launcher to Dexie live queries and render recent entries with notes
- expose conversation-opening actions and localized empty states so the dock reflects bookmark activity in real time
- update English and Dutch strings plus the retrofit log to capture the new behaviour and plan status

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e20763d550833386f51b5ac386215c