### PR TITLE
docs: require retrofit updates for feature changes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -20,6 +20,7 @@ Guidelines for agents contributing to the AI ChatGPT Companion extension.
 - Storage interactions go through a central service (add in `src/shared` or a dedicated `core/` namespace).
 - Background service worker handles downloads, alarms, cross-surface messaging.
 - Keep localization keys in `src/shared/i18n/locales/{lang}/common.json`; update both EN and NL.
+- Whenever functionality changes, update `retrofit.md`—at minimum refresh the status tables and logbook, and capture QA notes—to keep traceability intact.
 
 ## 4. Testing & QA
 - Minimum: run `npm run lint`, `npm run test`, and `npm run build` before submitting changes.


### PR DESCRIPTION
## Summary
- note in the agent handbook that feature updates must refresh retrofit.md status tables, logbook, and QA notes for traceability

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e20f20fa54833390796c52df6aa6ea