### PR TITLE
feat: add prompt launcher instruction popover

### DIFF
--- a/retrofit.md
+++ b/retrofit.md
@@ -15,7 +15,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | Media & audio | Audio capture, mediagalerij, voice presets, audio cues | 💤 Gepland | _nog te plannen_ |
 | Richting & instellingen | Dynamische taal/dir, settings-tab | 🚧 Ontwikkeling | _bijwerken tijdens iteratie_ |
 | Info & betalingen | Release notes, billing CTA, webhook-poller | 📝 Ontwerp | _nog te plannen_ |
-| Composer uitbreidingen | Telleroverlay, placeholderhelper, instructieoverlay, ketentab | 🚧 Ontwikkeling | 2025-10-06 – _pending_ (composer placeholder helper) |
+| Composer uitbreidingen | Telleroverlay, placeholderhelper, instructieoverlay, ketentab | 🚧 Ontwikkeling | 2025-10-06 – _pending_ (ketentab volgt) |
 | Onboarding & gidsen | Guides dataset, kaart in options/popup, modal in content | 📝 Ontwerp | _nog te plannen_ |
 | Internationalisatie | Locale-generator, initI18n updates, RTL helpers, tests | 📝 Ontwerp | _nog te plannen_ |
 | Iconen, beelden & audio | Icon-generator, styleguide, media-assets, notificatiesound | 📝 Ontwerp | _nog te plannen_ |
@@ -110,7 +110,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 ### 10. Composer uitbreidingen (`scripts/counter`, `scripts/textareaPrompts`)
 - [x] Introduceer `initComposerCounters` in `src/content/textareaPrompts.ts` die, naar analogie met `example/example/1/scripts/counter/injectWordsCounter.js`, via een `MutationObserver` de actieve ChatGPT-composer detecteert. Render een `div[data-ai-companion="composer-counters"]` in dezelfde shadow-root als de promptlauncher en toon woorden-, tekens- en tokenaantallen. Baseer tokenlimits op `settingsStore.maxTokens` (fallback 4096) en kleur de badge rood zodra limieten overschreden worden.
 - [x] Vervang de placeholderlogica in `textareaPrompts` door een helper `updateComposerPlaceholder(language, promptHint)` die het bestaande `CHATGPT_PROMPT_PLACEHOLDER`-patroon uit de voorbeeldmanifest ("Message ChatGPT Normally, Use // ...") gebruikt. Luister naar `chrome.storage.onChanged` zodat taalwissels of aangepaste hints direct worden toegepast zoals in `scripts/textareaPrompts/changeDefaultPlaceholder.js`.
-- [ ] Voeg een instructieoverlay toe gebaseerd op `example/example/1/scripts/textareaPrompts/promptListInstructions.js`: richt een `Popover`-component in `src/ui/components` in die de combinaties `//` (prompt), `..` (keten) en `@@` (bookmark) uitlegt. Toon deze overlay de eerste drie keer nadat de launcher openklapt en bewaar de teller in `settingsStore.dismissedLauncherTips`.
+- [x] Voeg een instructieoverlay toe gebaseerd op `example/example/1/scripts/textareaPrompts/promptListInstructions.js`: richt een `Popover`-component in `src/ui/components` in die de combinaties `//` (prompt), `..` (keten) en `@@` (bookmark) uitlegt. Toon deze overlay de eerste drie keer nadat de launcher openklapt en bewaar de teller in `settingsStore.dismissedLauncherTips`.
 - [ ] Breid het launcherpanel uit met een tab "Ketens" waarin `PromptChainRecord`s compact getoond worden (titel, aantal stappen, laatst gebruikt). Hergebruik de instructies uit `scripts/textareaPrompts/chainListUI.js` door een React-versie (`ChainPreviewList`) te bouwen. Center de call-to-action "Start keten" rechtsboven en koppel aan het `content/run-chain` bericht dat in sectie 4 wordt toegevoegd.
 
 ### 11. Onboarding en gidsen (`assets/data/guides.json`, `html/infoAndUpdates`)
@@ -165,5 +165,6 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | 2025-10-05 | 4a71f23 | Composer uitbreidingen | initComposerCounters + composer telleroverlay; lint/test/build uitgevoerd |
 | 2025-10-06 | _pending_ | Composer uitbreidingen | Placeholder helper + settings promptHint sync; lint/test/build uitgevoerd |
 | 2025-10-06 | _pending_ | Bladwijzers & contextmenu | Contextmenu met bookmark/prompt/pin/copy-acties + toastfeedback toegevoegd; lint/test/build gepland |
+| 2025-10-06 | _pending_ | Composer uitbreidingen | Launcher-instructiepopover + teller in settings; lint/test/build uitgevoerd |
 | _vul in_ | _vul in_ | _vul in_ | _korte notitie over tests, regressies, follow-up_ |
 

--- a/src/ui/components/Popover.ts
+++ b/src/ui/components/Popover.ts
@@ -1,0 +1,117 @@
+export interface PopoverShortcutConfig {
+  id: string;
+  key: string;
+}
+
+export interface PopoverOptions {
+  shortcuts: PopoverShortcutConfig[];
+  onDismiss: (event: MouseEvent) => void;
+  rootClassName?: string;
+  cardClassName?: string;
+  titleClassName?: string;
+  subtitleClassName?: string;
+  listClassName?: string;
+  itemClassName?: string;
+  keyClassName?: string;
+  labelClassName?: string;
+  dismissButtonClassName?: string;
+}
+
+export interface PopoverInstance {
+  root: HTMLDivElement;
+  card: HTMLDivElement;
+  title: HTMLHeadingElement;
+  subtitle: HTMLParagraphElement;
+  list: HTMLUListElement;
+  itemLabels: Map<string, HTMLParagraphElement>;
+  dismissButton: HTMLButtonElement;
+}
+
+export function createPopover({
+  shortcuts,
+  onDismiss,
+  rootClassName,
+  cardClassName,
+  titleClassName,
+  subtitleClassName,
+  listClassName,
+  itemClassName,
+  keyClassName,
+  labelClassName,
+  dismissButtonClassName
+}: PopoverOptions): PopoverInstance {
+  const root = document.createElement('div');
+  if (rootClassName) {
+    root.className = rootClassName;
+  }
+
+  const card = document.createElement('div');
+  if (cardClassName) {
+    card.className = cardClassName;
+  }
+  root.appendChild(card);
+
+  const title = document.createElement('h3');
+  if (titleClassName) {
+    title.className = titleClassName;
+  }
+  card.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  if (subtitleClassName) {
+    subtitle.className = subtitleClassName;
+  }
+  card.appendChild(subtitle);
+
+  const list = document.createElement('ul');
+  if (listClassName) {
+    list.className = listClassName;
+  }
+  card.appendChild(list);
+
+  const itemLabels = new Map<string, HTMLParagraphElement>();
+
+  for (const shortcut of shortcuts) {
+    const item = document.createElement('li');
+    if (itemClassName) {
+      item.className = itemClassName;
+    }
+    list.appendChild(item);
+
+    const key = document.createElement('span');
+    if (keyClassName) {
+      key.className = keyClassName;
+    }
+    key.textContent = shortcut.key;
+    item.appendChild(key);
+
+    const label = document.createElement('p');
+    if (labelClassName) {
+      label.className = labelClassName;
+    }
+    item.appendChild(label);
+    itemLabels.set(shortcut.id, label);
+  }
+
+  const dismissButton = document.createElement('button');
+  dismissButton.type = 'button';
+  if (dismissButtonClassName) {
+    dismissButton.className = dismissButtonClassName;
+  }
+  if (typeof dismissButton.addEventListener === 'function') {
+    dismissButton.addEventListener('click', onDismiss);
+  } else {
+    (dismissButton as unknown as { onclick?: (event: MouseEvent) => void }).onclick = onDismiss;
+  }
+  card.appendChild(dismissButton);
+
+  return {
+    root,
+    card,
+    title,
+    subtitle,
+    list,
+    itemLabels,
+    dismissButton
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable DOM popover helper for instruction overlays
- surface a launcher popover in the content script that explains shortcut prefixes and tracks dismissals in settings
- extend the retrofit log to capture the completed overlay work

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e221ed20ec8333bb1a28cde16249fe