### PR TITLE
feat: add prompt chain launcher tab and runner

### DIFF
--- a/retrofit.md
+++ b/retrofit.md
@@ -15,7 +15,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | Media & audio | Audio capture, mediagalerij, voice presets, audio cues | 💤 Gepland | _nog te plannen_ |
 | Richting & instellingen | Dynamische taal/dir, settings-tab | 🚧 Ontwikkeling | _bijwerken tijdens iteratie_ |
 | Info & betalingen | Release notes, billing CTA, webhook-poller | 📝 Ontwerp | _nog te plannen_ |
-| Composer uitbreidingen | Telleroverlay, placeholderhelper, instructieoverlay, ketentab | 🚧 Ontwikkeling | 2025-10-06 – _pending_ (ketentab volgt) |
+| Composer uitbreidingen | Telleroverlay, placeholderhelper, instructieoverlay, ketentab | 🚧 Ontwikkeling | 2025-10-07 – _pending_ (ketentab live, keten-runner QA volgt) |
 | Onboarding & gidsen | Guides dataset, kaart in options/popup, modal in content | 📝 Ontwerp | _nog te plannen_ |
 | Internationalisatie | Locale-generator, initI18n updates, RTL helpers, tests | 📝 Ontwerp | _nog te plannen_ |
 | Iconen, beelden & audio | Icon-generator, styleguide, media-assets, notificatiesound | 📝 Ontwerp | _nog te plannen_ |
@@ -121,7 +121,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 - [x] Introduceer `initComposerCounters` in `src/content/textareaPrompts.ts` die, naar analogie met `example/example/1/scripts/counter/injectWordsCounter.js`, via een `MutationObserver` de actieve ChatGPT-composer detecteert. Render een `div[data-ai-companion="composer-counters"]` in dezelfde shadow-root als de promptlauncher en toon woorden-, tekens- en tokenaantallen. Baseer tokenlimits op `settingsStore.maxTokens` (fallback 4096) en kleur de badge rood zodra limieten overschreden worden.
 - [x] Vervang de placeholderlogica in `textareaPrompts` door een helper `updateComposerPlaceholder(language, promptHint)` die het bestaande `CHATGPT_PROMPT_PLACEHOLDER`-patroon uit de voorbeeldmanifest ("Message ChatGPT Normally, Use // ...") gebruikt. Luister naar `chrome.storage.onChanged` zodat taalwissels of aangepaste hints direct worden toegepast zoals in `scripts/textareaPrompts/changeDefaultPlaceholder.js`.
 - [x] Voeg een instructieoverlay toe gebaseerd op `example/example/1/scripts/textareaPrompts/promptListInstructions.js`: richt een `Popover`-component in `src/ui/components` in die de combinaties `//` (prompt), `..` (keten) en `@@` (bookmark) uitlegt. Toon deze overlay de eerste drie keer nadat de launcher openklapt en bewaar de teller in `settingsStore.dismissedLauncherTips`.
-- [ ] Breid het launcherpanel uit met een tab "Ketens" waarin `PromptChainRecord`s compact getoond worden (titel, aantal stappen, laatst gebruikt). Hergebruik de instructies uit `scripts/textareaPrompts/chainListUI.js` door een React-versie (`ChainPreviewList`) te bouwen. Center de call-to-action "Start keten" rechtsboven en koppel aan het `content/run-chain` bericht dat in sectie 4 wordt toegevoegd.
+- [x] Breid het launcherpanel uit met een tab "Ketens" waarin `PromptChainRecord`s compact getoond worden (titel, aantal stappen, laatst gebruikt). Hergebruik de instructies uit `scripts/textareaPrompts/chainListUI.js` door een React-versie (`ChainPreviewList`) te bouwen. Center de call-to-action "Start keten" rechtsboven en koppel aan het `content/run-chain` bericht dat in sectie 4 wordt toegevoegd. _(2025-10-07 – content runner + launcher UI live)_
 
 ### 11. Onboarding en gidsen (`assets/data/guides.json`, `html/infoAndUpdates`)
 1. Kopieer `example/example/1/assets/data/guides.json` naar `public/guides.json` en breid het schema uit met `title`, `description` en `badgeColor` zodat we eigen copy kunnen plaatsen. Maak een type `GuideResource` in `src/core/models/guides.ts` met validatie via Zod.
@@ -177,5 +177,6 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | 2025-10-06 | _pending_ | Bladwijzers & contextmenu | Contextmenu met bookmark/prompt/pin/copy-acties + toastfeedback toegevoegd; lint/test/build gepland |
 | 2025-10-06 | _pending_ | Composer uitbreidingen | Launcher-instructiepopover + teller in settings; lint/test/build uitgevoerd |
 | 2025-10-07 | _pending_ | Bladwijzers & contextmenu | Contextmenu sluit bij unmount; accessibiliteitsnotitie + E2E-plan toegevoegd; lint/test/build gepland |
+| 2025-10-07 | _pending_ | Composer uitbreidingen | Ketentab + ketenrunner in launcher; npm run lint/test/build uitgevoerd |
 | _vul in_ | _vul in_ | _vul in_ | _korte notitie over tests, regressies, follow-up_ |
 

--- a/src/content/chainRunner.ts
+++ b/src/content/chainRunner.ts
@@ -1,0 +1,75 @@
+import type { PromptRecord } from '@/core/models';
+import { getPromptChainById, updatePromptChain } from '@/core/storage';
+import { db } from '@/core/storage/db';
+import { usePromptChainsStore } from '@/shared/state/promptChainsStore';
+import { insertTextIntoComposer } from './textareaPrompts';
+
+const STEP_DELAY_MS = 250;
+
+export type PromptChainRunResult =
+  | { status: 'completed'; chainId: string; executedAt: string; steps: number }
+  | { status: 'busy' }
+  | { status: 'not_found' }
+  | { status: 'empty' }
+  | { status: 'error'; message: string };
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runPromptChainById(chainId: string): Promise<PromptChainRunResult> {
+  const runtime = usePromptChainsStore.getState();
+  if (runtime.status === 'running') {
+    return { status: 'busy' };
+  }
+
+  const chain = await getPromptChainById(chainId);
+  if (!chain) {
+    return { status: 'not_found' };
+  }
+
+  if (chain.nodeIds.length === 0) {
+    return { status: 'empty' };
+  }
+
+  const records = await db.prompts.bulkGet(chain.nodeIds);
+  const prompts = chain.nodeIds
+    .map((_, index) => records[index])
+    .filter((record): record is PromptRecord => Boolean(record));
+
+  if (prompts.length === 0) {
+    return { status: 'empty' };
+  }
+
+  if (prompts.length !== chain.nodeIds.length) {
+    console.warn('[ai-companion] some prompt chain steps are missing prompts and will be skipped');
+  }
+
+  usePromptChainsStore.getState().startRun(chainId, prompts.length);
+
+  try {
+    for (let index = 0; index < prompts.length; index += 1) {
+      const prompt = prompts[index];
+      const text = index === 0 ? prompt.content : `\n\n${prompt.content}`;
+      const inserted = insertTextIntoComposer(text);
+      if (!inserted) {
+        usePromptChainsStore.getState().failRun('Composer unavailable');
+        return { status: 'error', message: 'composer_unavailable' };
+      }
+
+      usePromptChainsStore.getState().advanceRun(index + 1);
+      if (index < prompts.length - 1) {
+        await delay(STEP_DELAY_MS);
+      }
+    }
+
+    const executedAt = new Date().toISOString();
+    await updatePromptChain({ id: chainId, lastExecutedAt: executedAt });
+    usePromptChainsStore.getState().completeRun(executedAt);
+    return { status: 'completed', chainId, executedAt, steps: prompts.length };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error';
+    usePromptChainsStore.getState().failRun(message);
+    return { status: 'error', message };
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -5,6 +5,7 @@ import { createRuntimeMessageRouter, sendRuntimeMessage } from '@/shared/messagi
 import { initializeSettingsStore } from '@/shared/state/settingsStore';
 import { collectMessageElements, getConversationId, getConversationTitle } from './chatDom';
 import { mountPromptLauncher } from './textareaPrompts';
+import { runPromptChainById } from './chainRunner';
 
 void initializeSettingsStore();
 
@@ -126,6 +127,10 @@ function registerMessageHandlers() {
   messageRouter.register('content/audio-download', async () => {
     console.debug('[ai-companion] download audio requested');
     return { status: 'pending' } as const;
+  });
+
+  messageRouter.register('content/run-chain', async ({ chainId }) => {
+    return runPromptChainById(chainId);
   });
 
   messageRouter.attach();

--- a/src/core/models/records.ts
+++ b/src/core/models/records.ts
@@ -48,8 +48,10 @@ export interface PromptChainRecord {
   id: string;
   name: string;
   nodeIds: string[];
+  variables: string[];
   createdAt: string;
   updatedAt: string;
+  lastExecutedAt: string | null;
 }
 
 export interface FolderRecord {

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -230,6 +230,24 @@
       "closePanelAria": "Close bubble panel"
     },
     "bubblePanels": {
+      "chains": {
+        "title": "Prompt chains",
+        "emptyTitle": "No chains yet",
+        "emptySubtitle": "Group prompts into chains in the dashboard to launch them here.",
+        "stepCountOne": "1 step",
+        "stepCountOther": "{{count}} steps",
+        "lastUsed": "Last used {{time}}",
+        "lastUsedNever": "Not run yet",
+        "runningStatus": "Running ({{current}} / {{total}})",
+        "busyStatus": "Another chain is running",
+        "errorStatus": "Failed: {{message}}",
+        "genericError": "Something went wrong",
+        "completedStatus": "Completed {{time}}",
+        "startButton": "Start chain",
+        "runningButton": "Running…",
+        "startAria": "Start chain {{name}}",
+        "variablesLabel": "Variables: {{count}}"
+      },
       "bookmarks": {
         "title": "Conversation bookmarks",
         "emptyTitle": "No bookmarks yet",
@@ -369,7 +387,12 @@
       "insertButton": "Insert",
       "updatedAt": "Updated {{time}}",
       "folderLabel": "Folder: {{name}}",
-      "closeAria": "Close prompt launcher"
+      "closeAria": "Close prompt launcher",
+      "tips": {
+        "prompts": "Type // to browse saved prompts.",
+        "chains": "Use .. to launch prompt chains.",
+        "bookmarks": "Try @@ to bookmark the current message."
+      }
     },
     "composerCounters": {
       "wordsLabel": "Words",
@@ -380,6 +403,8 @@
     "dock": {
       "prompts": "Prompts ({{count}})",
       "promptsAria": "Toggle prompts dock ({{count}} available)",
+      "chains": "Chains ({{count}})",
+      "chainsAria": "Open chains bubble ({{count}} available)",
       "dashboard": "Dashboard",
       "dashboardAria": "Open dashboard"
     }

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -230,6 +230,24 @@
       "closePanelAria": "Bubbelpaneel sluiten"
     },
     "bubblePanels": {
+      "chains": {
+        "title": "Promptketens",
+        "emptyTitle": "Nog geen ketens",
+        "emptySubtitle": "Bundel prompts tot ketens in het dashboard om ze hier te starten.",
+        "stepCountOne": "1 stap",
+        "stepCountOther": "{{count}} stappen",
+        "lastUsed": "Laatst gebruikt {{time}}",
+        "lastUsedNever": "Nog niet uitgevoerd",
+        "runningStatus": "Bezig ({{current}} / {{total}})",
+        "busyStatus": "Er draait al een andere keten",
+        "errorStatus": "Mislukt: {{message}}",
+        "genericError": "Er ging iets mis",
+        "completedStatus": "Afgerond {{time}}",
+        "startButton": "Keten starten",
+        "runningButton": "Bezig…",
+        "startAria": "Keten {{name}} starten",
+        "variablesLabel": "Variabelen: {{count}}"
+      },
       "bookmarks": {
         "title": "Gespreksbladwijzers",
         "emptyTitle": "Nog geen bladwijzers",
@@ -369,7 +387,12 @@
       "insertButton": "Invoegen",
       "updatedAt": "Bijgewerkt {{time}}",
       "folderLabel": "Map: {{name}}",
-      "closeAria": "Promptmenu sluiten"
+      "closeAria": "Promptmenu sluiten",
+      "tips": {
+        "prompts": "Typ // om opgeslagen prompts te openen.",
+        "chains": "Gebruik .. om promptketens te starten.",
+        "bookmarks": "Gebruik @@ om het huidige bericht te bookmarken."
+      }
     },
     "composerCounters": {
       "wordsLabel": "Woorden",
@@ -380,6 +403,8 @@
     "dock": {
       "prompts": "Prompts ({{count}})",
       "promptsAria": "Promptmenu openen of sluiten ({{count}} beschikbaar)",
+      "chains": "Ketens ({{count}})",
+      "chainsAria": "Ketensbubbel openen ({{count}} beschikbaar)",
       "dashboard": "Dashboard",
       "dashboardAria": "Dashboard openen"
     }

--- a/src/shared/messaging/contracts.ts
+++ b/src/shared/messaging/contracts.ts
@@ -34,6 +34,15 @@ export interface RuntimeMessageMap extends MessageMapDefinition {
     request: { conversationId?: string | null; messageId?: string | null };
     response: { status: 'pending' };
   };
+  'content/run-chain': {
+    request: { chainId: string };
+    response:
+      | { status: 'completed'; chainId: string; executedAt: string; steps: number }
+      | { status: 'busy' }
+      | { status: 'not_found' }
+      | { status: 'empty' }
+      | { status: 'error'; message: string };
+  };
   'jobs/schedule-export': {
     request: {
       exportId: string;

--- a/src/shared/state/promptChainsStore.ts
+++ b/src/shared/state/promptChainsStore.ts
@@ -1,0 +1,81 @@
+import { create } from 'zustand';
+
+export type PromptChainRunStatus = 'idle' | 'running' | 'completed' | 'error';
+
+interface PromptChainsRuntimeState {
+  activeChainId: string | null;
+  status: PromptChainRunStatus;
+  totalSteps: number;
+  completedSteps: number;
+  error: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface PromptChainsRuntimeActions {
+  startRun: (chainId: string, totalSteps: number) => void;
+  advanceRun: (completedSteps: number) => void;
+  completeRun: (completedAt?: string) => void;
+  failRun: (message: string) => void;
+  reset: () => void;
+}
+
+export type PromptChainsStore = PromptChainsRuntimeState & PromptChainsRuntimeActions;
+
+const initialState: PromptChainsRuntimeState = {
+  activeChainId: null,
+  status: 'idle',
+  totalSteps: 0,
+  completedSteps: 0,
+  error: null,
+  startedAt: null,
+  completedAt: null
+};
+
+export const usePromptChainsStore = create<PromptChainsStore>((set) => ({
+  ...initialState,
+  startRun: (chainId, totalSteps) =>
+    set({
+      activeChainId: chainId,
+      status: 'running',
+      totalSteps: Math.max(0, totalSteps),
+      completedSteps: 0,
+      error: null,
+      startedAt: new Date().toISOString(),
+      completedAt: null
+    }),
+  advanceRun: (completedSteps) =>
+    set((state) => {
+      if (state.status !== 'running') {
+        return {};
+      }
+      const total = state.totalSteps > 0 ? state.totalSteps : completedSteps;
+      const clamped = Math.min(Math.max(completedSteps, 0), total);
+      return {
+        completedSteps: clamped,
+        totalSteps: total
+      };
+    }),
+  completeRun: (completedAt) =>
+    set((state) => {
+      if (!state.activeChainId) {
+        return {};
+      }
+      const timestamp = completedAt ?? new Date().toISOString();
+      const total = state.totalSteps > 0 ? state.totalSteps : state.completedSteps;
+      return {
+        status: 'completed',
+        completedSteps: total,
+        completedAt: timestamp,
+        error: null
+      };
+    }),
+  failRun: (message) =>
+    set((state) => ({
+      status: 'error',
+      error: message,
+      completedAt: new Date().toISOString(),
+      completedSteps: state.completedSteps
+    })),
+  reset: () => set(initialState)
+}));


### PR DESCRIPTION
## Summary
- add a prompt chain tab to the composer launcher with localized metadata and CTA wiring
- implement a runtime store plus chain runner that streams prompts into the composer via a new content message
- extend prompt chain models/storage, translations, and retrofit docs with last-executed tracking and updated tests

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2282f4bf48333bd7dbcc073aadaaf