### PR TITLE
feat: enrich bookmark modal with preview badges

### DIFF
--- a/retrofit.md
+++ b/retrofit.md
@@ -8,7 +8,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | --- | --- | --- | --- |
 | Conversatiedock & bubbels | Shadow-root host, dock rechts, contextuele bubbels, sneltoetsen | ✅ Gereed | 2024-06-15 |
 | Pin- & bulkbeheer | Pinned-overzicht, bulkacties, verplaatsingen, favoriete mappen | 🚧 Ontwikkeling | _bijwerken tijdens iteratie_ |
-| Bladwijzers & contextmenu | Bubbelgestuurde acties, notitiemodaal, contextmenu, popup-sync | 🚧 Ontwikkeling | 2025-10-07 – pending (bookmark-modal overlay + metadata sync) |
+| Bladwijzers & contextmenu | Bubbelgestuurde acties, notitiemodaal, contextmenu, popup-sync | 🚧 Ontwikkeling | 2025-10-08 – 6361a26 (bookmark-modal preview + regressietest) |
 | Promptbibliotheek & ketens | Variabelen, invulscherm, chain runner, GPT-koppelingen | 📝 Ontwerp | _nog te plannen_ |
 | Mapbeheer & GPT's | Drag & drop, inline create, GPT-detailmodaal, import/export | 📝 Ontwerp | _nog te plannen_ |
 | Conversatieanalyse & export | Full-text search, analytics, export-UI | 📝 Ontwerp | _nog te plannen_ |
@@ -46,13 +46,16 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 - **Verplaatsdialogen** – Gedeelde `MoveDialog` component staat in `src/ui/components/MoveDialog.tsx` en is verbonden met zowel de dock-kaarten als de conversation-tabel in options. Conversations krijgen nu een "Verplaats"-knop die via `upsertConversation` de map bijwerkt.
 - **Pinned workflow** – Pinned-lijst toont favorieten en gebruikt dezelfde dialoog; folder-snelkoppelingen tonen nieuwe `Fav`-badges.
 
+## Sessieresultaten 2025-10-08
+
+- **Bookmark-modal preview** – Bubble-overlay toont nu messagePreview + opgeslagen-badge binnen `BookmarkDialog`; popup toont dezelfde metadata. Regressietest `tests/content/bookmarks.test.ts` waarborgt opslagpad voor `toggleBookmark`.
+
 ## Volgende stappen
 
 1. **Bladwijzer-overlay afronden** –
-   - Verplaats de huidige `collectMessageElements`-flow in `src/content/ui-root.tsx` naar een bubbelgestuurd paneel zodat selectie en acties op één plaats samenkomen.
-   - Bouw een modal binnen de shadow-root (hergebruik `Modal`) die notities opslaat via `toggleBookmark` en een inline preview toont. Gebruik `BookmarkSummary` als basiscomponent en breid deze uit met `messagePreview` en `createdAt` badges.
-   - Migreer `db.bookmarks` met een Dexie `version(7)` stap die ontbrekende `messagePreview`-velden invult via een fallback (`conversation.latestMessage?.slice(0, 200) ?? ''`). Val terug op oude records indien de migratie faalt en log een QA-item.
-   - Synchroniseer de nieuwe velden naar popup/options door `useRecentBookmarks` uit te breiden en een regressietest toe te voegen in `tests/content/bookmarks.test.ts` die het modalpad en Dexie-opslag controleert.
+   - ✅ Modal binnen de shadow-root toont nu een inline preview, bestaande notitie en "saved"-badge met `createdAt`-tijdstempel (`BookmarkDialog`).
+   - ✅ `useRecentBookmarks` en popup/options surface tonen `messagePreview` en notities; regressietest `tests/content/bookmarks.test.ts` bewaakt toggle-pad en Dexie-opslag.
+   - 🔁 QA: bij volgende iteratie smoke-test uitvoeren op Chrome/Edge om regressie op echte ChatGPT-DOM te verifiëren.
 2. **Contextmenu herintroduceren** – ✅ Custom contextmenu beschikbaar vanuit de chatberichten met acties voor bookmarken, prompt opslaan, kopiëren en pinnen (rendered via `CompanionSidebarRoot`). Laatste updates:
    - ✅ Guard toegevoegd die het menu sluit bij unmount van `CompanionSidebarRoot` en bij het verbergen van de sidebar.
    - ✅ Toetscombinaties en toegankelijkheidslabels vastgelegd in `docs/accessibility/context-menu.md` + Playwright-scenarioplan vastgelegd in `tests/e2e/context-menu.spec.ts`.

--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -503,6 +503,37 @@ function BookmarkDialog({ open, onClose, initialTarget, t }: BookmarkDialogProps
                   </ul>
                 )}
               </div>
+              {selectedCandidate ? (
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                      {t('content.sidebar.history.bookmarkModalPreviewLabel', { defaultValue: 'Preview' })}
+                    </span>
+                    {selectedBookmark?.createdAt ? (
+                      <span className="rounded-full border border-white/10 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-300">
+                        {t('content.sidebar.history.bookmarkModalSavedAt', {
+                          defaultValue: 'Saved {{time}}',
+                          time: formatDateTime(selectedBookmark.createdAt)
+                        })}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="rounded-md border border-white/5 bg-slate-900/70 px-3 py-2 text-sm text-slate-200">
+                    {selectedBookmark?.messagePreview ?? selectedCandidate.subtitle ??
+                      t('content.sidebar.history.bookmarkModalPreviewFallback', {
+                        defaultValue: 'No preview available yet.'
+                      })}
+                  </p>
+                  {selectedBookmark?.note ? (
+                    <p className="text-xs text-slate-400">
+                      {t('content.sidebar.history.bookmarkModalExistingNote', {
+                        defaultValue: 'Existing note: {{note}}',
+                        note: selectedBookmark.note
+                      })}
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
               <div className="space-y-2">
                 <label
                   className="text-xs font-semibold uppercase tracking-wide text-slate-400"

--- a/tests/content/bookmarks.test.ts
+++ b/tests/content/bookmarks.test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+
+import { collectMessageElements } from '@/content/chatDom';
+import type { ConversationRecord, MessageRecord } from '@/core/models';
+import { db, getBookmarks, getRecentBookmarks, resetDatabase, toggleBookmark } from '@/core/storage';
+import { setupDomEnvironment } from '../utils/domEnvironment';
+
+type AsyncTest = [name: string, execute: () => Promise<void>];
+
+function createConversationRecord(overrides: Partial<ConversationRecord>): ConversationRecord {
+  const timestamp = new Date('2025-10-08T12:00:00.000Z').toISOString();
+  return {
+    id: 'conversation-1',
+    title: 'Test conversation title for bookmarks',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    folderId: undefined,
+    pinned: false,
+    wordCount: 120,
+    charCount: 640,
+    archived: false,
+    ...overrides
+  } satisfies ConversationRecord;
+}
+
+function createMessageRecord(overrides: Partial<MessageRecord>): MessageRecord {
+  const timestamp = new Date('2025-10-08T12:05:00.000Z').toISOString();
+  return {
+    id: 'message-1',
+    conversationId: 'conversation-1',
+    role: 'assistant',
+    content: 'Assistant reply content',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    wordCount: 42,
+    charCount: 240,
+    metadata: {},
+    ...overrides
+  } satisfies MessageRecord;
+}
+
+const tests: AsyncTest[] = [
+  [
+    'stores bookmarks with message previews and notes',
+    async () => {
+      const env = setupDomEnvironment();
+      try {
+        await resetDatabase();
+
+        const conversation = createConversationRecord({ id: 'conversation-a' });
+        const messageContent = `${'Prompt '.repeat(20)}${'A'.repeat(220)}`;
+        const message = createMessageRecord({
+          id: 'message-a',
+          conversationId: conversation.id,
+          content: messageContent,
+          metadata: undefined
+        });
+
+        await db.conversations.put(conversation);
+        await db.messages.put(message);
+
+        const messageElement = env.document.createElement('div');
+        messageElement.setAttribute('data-message-author-role', 'assistant');
+        messageElement.setAttribute('data-message-id', message.id);
+        messageElement.textContent = messageContent;
+        env.document.body.appendChild(messageElement);
+
+        const nodes = collectMessageElements();
+        assert.equal(nodes.length, 1);
+        assert.equal(nodes[0].getAttribute('data-message-id'), message.id);
+
+        const result = await toggleBookmark(conversation.id, message.id, 'Important context');
+        assert.equal(result.removed, false);
+        assert.ok(result.bookmarkId);
+
+        const bookmarks = await getBookmarks(conversation.id);
+        assert.equal(bookmarks.length, 1);
+        const stored = bookmarks[0];
+        assert.equal(stored.messageId, message.id);
+        assert.equal(stored.note, 'Important context');
+        assert.match(stored.createdAt ?? '', /T/);
+        assert.ok(stored.messagePreview);
+        assert.ok(stored.messagePreview!.endsWith('…'));
+        assert.ok(stored.messagePreview!.length <= 200);
+
+        const summaries = await getRecentBookmarks(1);
+        assert.equal(summaries.length, 1);
+        const summary = summaries[0];
+        assert.equal(summary.id, stored.id);
+        assert.equal(summary.messageId, stored.messageId);
+        assert.equal(summary.messagePreview, stored.messagePreview);
+        assert.equal(summary.note, stored.note);
+        assert.equal(summary.createdAt, stored.createdAt);
+      } finally {
+        await resetDatabase();
+        env.cleanup();
+      }
+    }
+  ],
+  [
+    'falls back to conversation title preview when message content is unavailable',
+    async () => {
+      const env = setupDomEnvironment();
+      try {
+        await resetDatabase();
+
+        const conversation = createConversationRecord({ id: 'conversation-b', title: 'Deep dive into companion retrofits' });
+        await db.conversations.put(conversation);
+
+        const result = await toggleBookmark(conversation.id, undefined, undefined);
+        assert.equal(result.removed, false);
+
+        const bookmarks = await getBookmarks(conversation.id);
+        assert.equal(bookmarks.length, 1);
+        const stored = bookmarks[0];
+        assert.equal(stored.messageId, null);
+        assert.equal(stored.note, undefined);
+        assert.equal(stored.messagePreview, 'Deep dive into companion retrofits');
+
+        const summaries = await getRecentBookmarks(1);
+        assert.equal(summaries[0].messagePreview, stored.messagePreview);
+      } finally {
+        await resetDatabase();
+        env.cleanup();
+      }
+    }
+  ]
+];
+
+async function run() {
+  let hasFailure = false;
+
+  for (const [name, execute] of tests) {
+    try {
+      await execute();
+      console.log(`\u2713 ${name}`);
+    } catch (error) {
+      hasFailure = true;
+      console.error(`\u2717 ${name}`);
+      console.error(error);
+    }
+  }
+
+  if (hasFailure) {
+    process.exitCode = 1;
+  }
+}
+
+await run();

--- a/tests/mocks/inMemoryDb.ts
+++ b/tests/mocks/inMemoryDb.ts
@@ -14,6 +14,8 @@ type WhereResult<T extends RecordWithId> = {
   count(): Promise<number>;
   toArray(): Promise<T[]>;
   delete(): Promise<void>;
+  and(predicate: (item: T) => boolean): WhereResult<T>;
+  first(): Promise<T | undefined>;
 };
 
 type WhereQuery<T extends RecordWithId> = {
@@ -61,6 +63,14 @@ function createWhereResult<T extends RecordWithId>(
       for (const item of items) {
         table.deleteSync(item.id);
       }
+    },
+    and(predicate: (item: T) => boolean) {
+      const filtered = items.filter((item) => predicate(item));
+      return createWhereResult(table, filtered);
+    },
+    async first() {
+      const [first] = items;
+      return first ? clone(first) : undefined;
     }
   };
 }

--- a/tests/runAll.ts
+++ b/tests/runAll.ts
@@ -1,5 +1,6 @@
 async function runSequentially() {
   await import('./content/sidebarIntegration.spec');
+  await import('./content/bookmarks.test');
   await import('./promptChains.spec');
   await import('./conversationIngestion.spec');
   await import('./jobScheduler.spec');


### PR DESCRIPTION
## Summary
- surface bookmark previews, saved timestamps, and existing notes inside the content bubble modal so users see stored context before editing
- add a regression test covering bookmark persistence plus extend the in-memory Dexie mock to support chained filters used by toggleBookmark
- update retrofit notes with the latest bookmark modal progress reference

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e25ad211988333aafeca9fa768844d