### PR TITLE
Add guide resources dataset and schema

### DIFF
--- a/public/guides.json
+++ b/public/guides.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "guides": [
+    {
+      "id": "bookmark-overlay",
+      "title": "Bookmark overlay snelstart",
+      "description": "Leer hoe je berichten markeert vanuit het bubblemenu en notities bewaart zonder de chat te verlaten.",
+      "url": "https://docs.ai-companion.example/guides/bookmark-overlay",
+      "badgeColor": "emerald",
+      "topics": ["bookmarks", "context-menu"],
+      "estimatedTimeMinutes": 3
+    },
+    {
+      "id": "prompt-chains",
+      "title": "Promptketens bouwen",
+      "description": "Stel herbruikbare ketens samen met variabelen en deel ze via de launcher voor het hele team.",
+      "url": "https://docs.ai-companion.example/guides/prompt-chains",
+      "badgeColor": "violet",
+      "topics": ["prompts", "automation"],
+      "estimatedTimeMinutes": 6
+    },
+    {
+      "id": "history-and-pins",
+      "title": "Conversaties ordenen",
+      "description": "Gebruik favorieten, mappen en bulkacties om actieve gesprekken snel terug te vinden in het dock.",
+      "url": "https://docs.ai-companion.example/guides/history-and-pins",
+      "badgeColor": "sky",
+      "topics": ["history", "pins"],
+      "estimatedTimeMinutes": 4
+    }
+  ]
+}

--- a/retrofit.md
+++ b/retrofit.md
@@ -140,7 +140,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 - [x] Breid het launcherpanel uit met een tab "Ketens" waarin `PromptChainRecord`s compact getoond worden (titel, aantal stappen, laatst gebruikt). Hergebruik de instructies uit `scripts/textareaPrompts/chainListUI.js` door een React-versie (`ChainPreviewList`) te bouwen. Center de call-to-action "Start keten" rechtsboven en koppel aan het `content/run-chain` bericht dat in sectie 4 wordt toegevoegd. _(2025-10-07 – content runner + launcher UI live)_
 
 ### 11. Onboarding en gidsen (`assets/data/guides.json`, `html/infoAndUpdates`)
-1. Kopieer `example/example/1/assets/data/guides.json` naar `public/guides.json` en breid het schema uit met `title`, `description` en `badgeColor` zodat we eigen copy kunnen plaatsen. Maak een type `GuideResource` in `src/core/models/guides.ts` met validatie via Zod.
+1. ✅ Kopieer `example/example/1/assets/data/guides.json` naar `public/guides.json` en breid het schema uit met `title`, `description` en `badgeColor` zodat we eigen copy kunnen plaatsen. Maak een type `GuideResource` in `src/core/models/guides.ts` met validatie via Zod. _(2025-10-16 – dataset + schema live)_
 2. Bouw in `src/options/features/infoAndUpdates/GuideResourcesCard.tsx` een kaart die de gidsen toont met knoppen "Bekijken". Gebruik `chrome.tabs.create` om de Guideflow-URL in een nieuw tabblad te openen en log kliktelemetrie via `background/jobs/scheduler` (event `guide-opened`).
 3. Introduceer in `useSettingsStore` een veld `dismissedGuideIds: string[]`. Voeg een "Markeer als bekeken"-toggle toe per gids (zowel in options als in popup) en synchroniseer de status naar `chrome.storage.local` vergelijkbaar met het voorbeeld `setPreviousModal`/`setSelectedManageTabsItem` patroon.
 4. Plaats in het promptlauncher-dock een nieuwe bubble "Guides" die de `GuideResourcesCard` in een modal opent. Gebruik `Modal` component en zorg dat het modaal in de content-shadow-root rendert zodat de gebruiker in-context hulp krijgt zoals in `html/infoAndUpdates`.
@@ -202,5 +202,6 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | 2025-10-13 | _pending_ | Pin- & bulkbeheer | Dock-favorieten toggle + caching; npm run lint/test/build uitgevoerd |
 | 2025-10-14 | _pending_ | Richting & instellingen | RTL-synchronisatie + dashboard-instellingen; npm run lint/test/build |
 | 2025-10-15 | _pending_ | Bladwijzers & contextmenu | Actions-bubbel activeert selecties + snelle acties; npm run lint/test/build uitgevoerd |
+| 2025-10-16 | _pending_ | Onboarding & gidsen | Guides dataset + Zod-validatie toegevoegd; npm run lint/test uitgevoerd |
 | _vul in_ | _vul in_ | _vul in_ | _korte notitie over tests, regressies, follow-up_ |
 

--- a/src/core/models/guides.ts
+++ b/src/core/models/guides.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const badgeColorSchema = z.enum([
+  'emerald',
+  'sky',
+  'violet',
+  'amber',
+  'slate',
+  'rose',
+]);
+
+const guideTopicSchema = z.string().min(1, 'topic must not be empty');
+
+export const guideResourceSchema = z.object({
+  id: z.string().min(1, 'guide id is required'),
+  url: z.string().url('guide url must be a valid URL'),
+  title: z.string().min(1, 'guide title is required'),
+  description: z.string().min(1, 'guide description is required'),
+  badgeColor: badgeColorSchema,
+  topics: z.array(guideTopicSchema).default([]),
+  estimatedTimeMinutes: z
+    .number()
+    .int('estimated time must be an integer')
+    .positive('estimated time must be positive')
+    .optional(),
+});
+
+export type GuideResource = z.infer<typeof guideResourceSchema>;
+
+export const guidesFileSchema = z.object({
+  version: z
+    .number()
+    .int('version must be an integer')
+    .positive('version must be positive'),
+  guides: z.array(guideResourceSchema).min(1, 'at least one guide is required'),
+});
+
+export type GuidesFile = z.infer<typeof guidesFileSchema>;
+
+export function parseGuidesFile(payload: unknown): GuidesFile {
+  return guidesFileSchema.parse(payload);
+}

--- a/src/vendor/zod.ts
+++ b/src/vendor/zod.ts
@@ -1,0 +1,273 @@
+export type ZodPath = (string | number)[];
+
+export interface ZodIssue {
+  message: string;
+  path: ZodPath;
+}
+
+export class ZodError extends Error {
+  issues: ZodIssue[];
+
+  constructor(issues: ZodIssue[]) {
+    super(issues[0]?.message ?? 'Invalid input');
+    this.name = 'ZodError';
+    this.issues = issues;
+  }
+}
+
+export type SafeParseSuccess<T> = { success: true; data: T };
+export type SafeParseFailure = { success: false; error: ZodError };
+export type SafeParseReturnType<T> = SafeParseSuccess<T> | SafeParseFailure;
+
+type Parser<T> = (input: unknown, path: ZodPath) => T;
+
+type SchemaDef = {
+  type: string;
+  isOptional?: boolean;
+  hasDefault?: boolean;
+  defaultValue?: unknown;
+};
+
+export interface BaseSchema<T> {
+  _def: SchemaDef;
+  _parse(input: unknown, path: ZodPath): T;
+  parse(input: unknown): T;
+  safeParse(input: unknown): SafeParseReturnType<T>;
+  optional(): BaseSchema<T | undefined>;
+  default(value: T): BaseSchema<T>;
+}
+
+function createSchema<T>(parser: Parser<T>, def: SchemaDef): BaseSchema<T> {
+  const schema: BaseSchema<T> = {
+    _def: def,
+    _parse(value: unknown, path: ZodPath): T {
+      return parser(value, path);
+    },
+    parse(value: unknown): T {
+      return parser(value, []);
+    },
+    safeParse(value: unknown): SafeParseReturnType<T> {
+      try {
+        return { success: true, data: parser(value, []) };
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return { success: false, error };
+        }
+        throw error;
+      }
+    },
+    optional(): BaseSchema<T | undefined> {
+      return createSchema<T | undefined>(
+        (value, path) => {
+          if (value === undefined) {
+            return undefined;
+          }
+          return parser(value, path);
+        },
+        { ...def, isOptional: true }
+      );
+    },
+    default(value: T): BaseSchema<T> {
+      return createSchema<T>(
+        (input, path) => {
+          if (input === undefined) {
+            return value;
+          }
+          return parser(input, path);
+        },
+        { ...def, hasDefault: true, defaultValue: value }
+      );
+    }
+  };
+
+  return schema;
+}
+
+function createIssue(message: string, path: ZodPath): ZodIssue {
+  return { message, path };
+}
+
+export interface StringSchema extends BaseSchema<string> {
+  min(length: number, message?: string): StringSchema;
+  url(message?: string): StringSchema;
+}
+
+function string(): StringSchema {
+  const checks: Array<(value: string, path: ZodPath) => void> = [];
+
+  const schema = createSchema<string>(
+    (value, path) => {
+      if (typeof value !== 'string') {
+        throw new ZodError([createIssue('Expected string', path)]);
+      }
+      for (const check of checks) {
+        check(value, path);
+      }
+      return value;
+    },
+    { type: 'string' }
+  ) as StringSchema;
+
+  schema.min = (length: number, message = `Expected string length >= ${length}`) => {
+    checks.push((value, path) => {
+      if (value.length < length) {
+        throw new ZodError([createIssue(message, path)]);
+      }
+    });
+    return schema;
+  };
+
+  schema.url = (message = 'Expected URL') => {
+    checks.push((value, path) => {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(value);
+      } catch {
+        throw new ZodError([createIssue(message, path)]);
+      }
+    });
+    return schema;
+  };
+
+  return schema;
+}
+
+export interface NumberSchema extends BaseSchema<number> {
+  int(message?: string): NumberSchema;
+  positive(message?: string): NumberSchema;
+}
+
+function number(): NumberSchema {
+  const checks: Array<(value: number, path: ZodPath) => void> = [];
+
+  const schema = createSchema<number>(
+    (value, path) => {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        throw new ZodError([createIssue('Expected number', path)]);
+      }
+      for (const check of checks) {
+        check(value, path);
+      }
+      return value;
+    },
+    { type: 'number' }
+  ) as NumberSchema;
+
+  schema.int = (message = 'Expected integer') => {
+    checks.push((value, path) => {
+      if (!Number.isInteger(value)) {
+        throw new ZodError([createIssue(message, path)]);
+      }
+    });
+    return schema;
+  };
+
+  schema.positive = (message = 'Expected positive number') => {
+    checks.push((value, path) => {
+      if (value <= 0) {
+        throw new ZodError([createIssue(message, path)]);
+      }
+    });
+    return schema;
+  };
+
+  return schema;
+}
+
+export interface ArraySchema<T> extends BaseSchema<T[]> {
+  min(length: number, message?: string): ArraySchema<T>;
+}
+
+function array<T>(itemSchema: BaseSchema<T>): ArraySchema<T> {
+  const checks: Array<(value: T[], path: ZodPath) => void> = [];
+
+  const schema = createSchema<T[]>(
+    (value, path) => {
+      if (!Array.isArray(value)) {
+        throw new ZodError([createIssue('Expected array', path)]);
+      }
+      const result = value.map((entry, index) => itemSchema._parse(entry, [...path, index]));
+      for (const check of checks) {
+        check(result, path);
+      }
+      return result;
+    },
+    { type: 'array' }
+  ) as ArraySchema<T>;
+
+  schema.min = (length: number, message = `Expected array length >= ${length}`) => {
+    checks.push((value, path) => {
+      if (value.length < length) {
+        throw new ZodError([createIssue(message, path)]);
+      }
+    });
+    return schema;
+  };
+
+  return schema;
+}
+
+type EnumValues = [string, ...string[]];
+
+function enumType<TValues extends EnumValues>(values: TValues): BaseSchema<TValues[number]> {
+  const valueSet = new Set(values);
+
+  return createSchema<TValues[number]>(
+    (value, path) => {
+      if (typeof value !== 'string') {
+        throw new ZodError([createIssue('Expected string', path)]);
+      }
+      if (!valueSet.has(value)) {
+        throw new ZodError([createIssue(`Expected one of: ${values.join(', ')}`, path)]);
+      }
+      return value as TValues[number];
+    },
+    { type: 'enum' }
+  );
+}
+
+type ObjectShape = Record<string, BaseSchema<any>>;
+
+type ObjectResult<TShape extends ObjectShape> = {
+  [K in keyof TShape]: ReturnType<TShape[K]['parse']>;
+};
+
+function object<TShape extends ObjectShape>(shape: TShape): BaseSchema<ObjectResult<TShape>> {
+  return createSchema<ObjectResult<TShape>>(
+    (value, path) => {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new ZodError([createIssue('Expected object', path)]);
+      }
+
+      const result: Record<string, unknown> = {};
+      for (const key of Object.keys(shape)) {
+        const schema = shape[key];
+        const raw = (value as Record<string, unknown>)[key];
+        const parsed = schema._parse(raw, [...path, key]);
+        if (parsed !== undefined || raw !== undefined || schema._def.hasDefault) {
+          result[key] = parsed;
+        }
+      }
+
+      return result as ObjectResult<TShape>;
+    },
+    { type: 'object' }
+  );
+}
+
+const z = {
+  string,
+  number,
+  array,
+  enum: enumType,
+  object
+};
+
+export type Infer<TSchema extends BaseSchema<any>> = TSchema extends BaseSchema<infer T> ? T : never;
+
+export { z };
+
+export namespace z {
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  export type infer<TSchema extends BaseSchema<any>> = Infer<TSchema>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "types": ["chrome", "node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "zod": ["src/vendor/zod"]
     }
   },
   "include": ["src", "tests"],


### PR DESCRIPTION
## Summary
- seed `public/guides.json` with guide resources metadata for the onboarding flow
- add a `GuideResource` Zod schema and parser plus a lightweight Zod vendor shim
- update TypeScript path mapping and retrofit log for the new guides tranche

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e285470f248333a1519ace3609655f