### PR TITLE
feat: persist bubble launcher folder shortcuts

### DIFF
--- a/docs/testing/manual-regression.md
+++ b/docs/testing/manual-regression.md
@@ -66,7 +66,7 @@ Execute on `chat.openai.com`, then repeat on `chatgpt.com`.
 3. Unpin the first conversation in the dashboard table (via row actions) and confirm the popup no longer labels it as pinned after reopening.
 4. Open the bubble dock on an active ChatGPT conversation, switch to the “History” tab, and validate the folder shortcuts:
    - Toggle a folder to favorite via the star button and confirm the “Fav” badge appears next to the name.
-   - Refresh the tab or hide/show the dock to ensure the cached favorites render immediately without flicker.
+   - Refresh the tab or hide/show the dock and ensure the cached favorites render **immediately** before the folder tree reloads; repeat in a new tab to verify the chrome.storage cache.
    - Remove the favorite and note the star button disables while the change is persisted.
 5. With the same conversation in view, open the “Actions” bubble and select a message from the list. Verify that:
    - “Bookmark” opens the inline bookmark modal with the selected message preselected.

--- a/retrofit.md
+++ b/retrofit.md
@@ -75,7 +75,7 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
    - ✅ QA: Bulk-move gevalideerd op de dashboardtabel; regressiegids uitgebreid met stap 8 en logboek bijgewerkt.
 7. **Favoriete mappen in het dock beheren** –
    - ✅ Map-snelkoppelingen in de History-tab tonen sterknoppen zodat favorieten direct vanuit het bubbledock aangepast kunnen worden.
-   - ✅ `useBubbleLauncherStore` cachet nu de geflatteerde mapstructuur waardoor favorieten onmiddellijk zichtbaar zijn bij heropenen.
+   - ✅ `useBubbleLauncherStore` hydrateert via `chrome.storage.local` (`initializeBubbleLauncherStore`) en cachet de geflatteerde mapstructuur, zodat favorieten onmiddellijk zichtbaar zijn bij heropenen.
    - ✅ QA: Nieuwe regressiestap voor dock-favorieten toegevoegd aan [`docs/testing/manual-regression.md`](docs/testing/manual-regression.md#bookmark--pin-workflow).
 
 ## Prioriteiten en stappen per featuregroep
@@ -204,5 +204,6 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | 2025-10-15 | _pending_ | Bladwijzers & contextmenu | Actions-bubbel activeert selecties + snelle acties; npm run lint/test/build uitgevoerd |
 | 2025-10-16 | _pending_ | Onboarding & gidsen | Guides dataset + Zod-validatie toegevoegd; npm run lint/test uitgevoerd |
 | 2025-10-17 | _pending_ | Onboarding & gidsen | Options-gidsenkaart + telemetry event logging; npm run lint/test/build uitgevoerd |
+| 2025-10-18 | _pending_ | Pin- & bulkbeheer | Dock-favorieten cache hydrateert via chrome.storage; unit test bubbleLauncherStore + lint/test/build uitgevoerd |
 | _vul in_ | _vul in_ | _vul in_ | _korte notitie over tests, regressies, follow-up_ |
 

--- a/src/content/ui-root.tsx
+++ b/src/content/ui-root.tsx
@@ -27,6 +27,7 @@ import { usePrompts } from '@/shared/hooks/usePrompts';
 import { useRecentBookmarks } from '@/shared/hooks/useRecentBookmarks';
 import { useRecentConversations } from '@/shared/hooks/useRecentConversations';
 import {
+  initializeBubbleLauncherStore,
   useBubbleLauncherStore,
   type FolderShortcut
 } from '@/shared/state/bubbleLauncherStore';
@@ -2440,7 +2441,7 @@ function CompanionSidebarRoot({ host }: CompanionSidebarRootProps): ReactElement
 }
 
 async function init() {
-  await initializeSettingsStore();
+  await Promise.all([initializeSettingsStore(), initializeBubbleLauncherStore()]);
   const host = await ensureShadowHost();
   const container = mountReact(host);
   const root = createRoot(container);

--- a/src/shared/state/bubbleLauncherStore.ts
+++ b/src/shared/state/bubbleLauncherStore.ts
@@ -9,21 +9,298 @@ export interface FolderShortcut {
   favorite: boolean;
 }
 
-export interface BubbleLauncherState {
-  activeBubble: Bubble | null;
+interface BubbleLauncherSnapshot {
   conversationFolderShortcuts: FolderShortcut[];
+}
+
+export interface BubbleLauncherState extends BubbleLauncherSnapshot {
+  activeBubble: Bubble | null;
+  hydrated: boolean;
   setActiveBubble: (bubble: Bubble | null) => void;
   setConversationFolderShortcuts: (shortcuts: FolderShortcut[]) => void;
   toggleBubble: (bubble: Bubble) => void;
 }
 
-export const useBubbleLauncherStore = create<BubbleLauncherState>((set) => ({
+const BUBBLE_LAUNCHER_STORAGE_KEY = 'ai-companion:bubble-launcher:v1';
+
+const DEFAULT_SNAPSHOT: BubbleLauncherSnapshot = {
+  conversationFolderShortcuts: []
+};
+
+function coerceFolderShortcut(input: unknown): FolderShortcut | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  const record = input as Partial<FolderShortcut>;
+  const id = typeof record.id === 'string' && record.id.trim().length > 0 ? record.id.trim() : null;
+  const name = typeof record.name === 'string' && record.name.trim().length > 0 ? record.name.trim() : null;
+  const depth = Number.isFinite(record.depth) && Number(record.depth) >= 0 ? Math.floor(Number(record.depth)) : null;
+  const favorite = typeof record.favorite === 'boolean' ? record.favorite : false;
+
+  if (!id || !name || depth === null) {
+    return null;
+  }
+
+  return { id, name, depth, favorite } satisfies FolderShortcut;
+}
+
+function coerceSnapshot(input: unknown): BubbleLauncherSnapshot {
+  if (!input || typeof input !== 'object') {
+    return { ...DEFAULT_SNAPSHOT };
+  }
+
+  const record = input as Partial<BubbleLauncherSnapshot>;
+  const shortcuts = Array.isArray(record.conversationFolderShortcuts)
+    ? record.conversationFolderShortcuts
+        .map((shortcut) => coerceFolderShortcut(shortcut))
+        .filter((shortcut): shortcut is FolderShortcut => Boolean(shortcut))
+    : [];
+
+  return { conversationFolderShortcuts: shortcuts } satisfies BubbleLauncherSnapshot;
+}
+
+function cloneShortcuts(shortcuts: FolderShortcut[]): FolderShortcut[] {
+  return shortcuts.map((shortcut) => ({ ...shortcut }));
+}
+
+function areShortcutListsEqual(a: FolderShortcut[], b: FolderShortcut[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index];
+    const right = b[index];
+    if (
+      left.id !== right.id ||
+      left.name !== right.name ||
+      left.depth !== right.depth ||
+      left.favorite !== right.favorite
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getLocalStorageArea(): chrome.storage.StorageArea | undefined {
+  if (typeof chrome === 'undefined' || !chrome.storage?.local) {
+    return undefined;
+  }
+  return chrome.storage.local;
+}
+
+async function readStoredSnapshot(): Promise<BubbleLauncherSnapshot> {
+  const area = getLocalStorageArea();
+  if (!area) {
+    const fallback = fallbackStore.get(BUBBLE_LAUNCHER_STORAGE_KEY);
+    return fallback ? coerceSnapshot(fallback) : { ...DEFAULT_SNAPSHOT };
+  }
+
+  try {
+    if (typeof area.get === 'function') {
+      if (area.get.length === 1) {
+        const result = await (area.get as (key: string) => Promise<Record<string, unknown>>)(
+          BUBBLE_LAUNCHER_STORAGE_KEY
+        );
+        return coerceSnapshot(result?.[BUBBLE_LAUNCHER_STORAGE_KEY]);
+      }
+
+      return await new Promise<BubbleLauncherSnapshot>((resolve, reject) => {
+        try {
+          (area.get as (key: string, callback: (items: Record<string, unknown>) => void) => void)(
+            BUBBLE_LAUNCHER_STORAGE_KEY,
+            (items) => {
+              const lastError = (chrome as unknown as { runtime?: { lastError?: unknown } })?.runtime?.lastError;
+              if (lastError) {
+                reject(lastError);
+                return;
+              }
+              resolve(coerceSnapshot(items?.[BUBBLE_LAUNCHER_STORAGE_KEY]));
+            }
+          );
+        } catch (error) {
+          reject(error);
+        }
+      });
+    }
+  } catch (error) {
+    console.warn('[bubbleLauncherStore] failed to read snapshot from storage', error);
+  }
+
+  const fallback = fallbackStore.get(BUBBLE_LAUNCHER_STORAGE_KEY);
+  return fallback ? coerceSnapshot(fallback) : { ...DEFAULT_SNAPSHOT };
+}
+
+async function writeStoredSnapshot(snapshot: BubbleLauncherSnapshot): Promise<void> {
+  fallbackStore.set(BUBBLE_LAUNCHER_STORAGE_KEY, snapshot);
+
+  const area = getLocalStorageArea();
+  if (!area) {
+    return;
+  }
+
+  try {
+    const payload = { [BUBBLE_LAUNCHER_STORAGE_KEY]: snapshot } as Record<string, BubbleLauncherSnapshot>;
+    if (typeof area.set === 'function') {
+      if (area.set.length === 1) {
+        await (area.set as (items: Record<string, BubbleLauncherSnapshot>) => Promise<void>)(payload);
+        return;
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        try {
+          (area.set as (items: Record<string, BubbleLauncherSnapshot>, callback: () => void) => void)(payload, () => {
+            const lastError = (chrome as unknown as { runtime?: { lastError?: unknown } })?.runtime?.lastError;
+            if (lastError) {
+              reject(lastError);
+              return;
+            }
+            resolve();
+          });
+        } catch (error) {
+          reject(error);
+        }
+      });
+    }
+  } catch (error) {
+    console.warn('[bubbleLauncherStore] failed to persist snapshot', error);
+  }
+}
+
+function toSnapshot(state: BubbleLauncherState): BubbleLauncherSnapshot {
+  return {
+    conversationFolderShortcuts: cloneShortcuts(state.conversationFolderShortcuts)
+  } satisfies BubbleLauncherSnapshot;
+}
+
+function areSnapshotsEqual(a: BubbleLauncherSnapshot, b: BubbleLauncherSnapshot): boolean {
+  return areShortcutListsEqual(a.conversationFolderShortcuts, b.conversationFolderShortcuts);
+}
+
+const fallbackStore = new Map<string, BubbleLauncherSnapshot>();
+let initializePromise: Promise<void> | null = null;
+let unsubscribePersist: (() => void) | null = null;
+let storageListenerRegistered = false;
+let storageChangeListener: ((changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void) | null = null;
+let hydrating = false;
+let lastSnapshot: BubbleLauncherSnapshot = { ...DEFAULT_SNAPSHOT };
+
+export const useBubbleLauncherStore = create<BubbleLauncherState>((set, get) => ({
   activeBubble: null,
+  hydrated: false,
   conversationFolderShortcuts: [],
   setActiveBubble: (bubble) => set({ activeBubble: bubble }),
-  setConversationFolderShortcuts: (shortcuts) => set({ conversationFolderShortcuts: shortcuts }),
+  setConversationFolderShortcuts: (shortcuts) => {
+    const current = get().conversationFolderShortcuts;
+    if (areShortcutListsEqual(current, shortcuts)) {
+      return;
+    }
+    set({ conversationFolderShortcuts: cloneShortcuts(shortcuts) });
+  },
   toggleBubble: (bubble) =>
     set((state) => ({
       activeBubble: state.activeBubble === bubble ? null : bubble,
     })),
 }));
+
+function registerStorageListener() {
+  if (storageListenerRegistered) {
+    return;
+  }
+
+  if (typeof chrome === 'undefined' || !chrome.storage?.onChanged) {
+    return;
+  }
+
+  storageChangeListener = (changes, areaName) => {
+    if (areaName !== 'local') {
+      return;
+    }
+    const change = changes[BUBBLE_LAUNCHER_STORAGE_KEY];
+    if (!change) {
+      return;
+    }
+
+    const snapshot = coerceSnapshot(change.newValue);
+    fallbackStore.set(BUBBLE_LAUNCHER_STORAGE_KEY, snapshot);
+
+    hydrating = true;
+    useBubbleLauncherStore.setState((state) => ({
+      ...state,
+      conversationFolderShortcuts: cloneShortcuts(snapshot.conversationFolderShortcuts),
+      hydrated: true
+    }));
+    lastSnapshot = snapshot;
+    hydrating = false;
+  };
+
+  chrome.storage.onChanged.addListener(storageChangeListener);
+
+  storageListenerRegistered = true;
+}
+
+export async function initializeBubbleLauncherStore(): Promise<void> {
+  if (initializePromise) {
+    return initializePromise;
+  }
+
+  initializePromise = (async () => {
+    let snapshot = { ...DEFAULT_SNAPSHOT };
+    try {
+      snapshot = await readStoredSnapshot();
+    } catch (error) {
+      console.warn('[bubbleLauncherStore] falling back to default snapshot', error);
+    }
+
+    hydrating = true;
+    useBubbleLauncherStore.setState((state) => ({
+      ...state,
+      conversationFolderShortcuts: cloneShortcuts(snapshot.conversationFolderShortcuts),
+      hydrated: true
+    }));
+    lastSnapshot = snapshot;
+    hydrating = false;
+
+    if (!unsubscribePersist) {
+      unsubscribePersist = useBubbleLauncherStore.subscribe((state) => {
+        if (hydrating) {
+          return;
+        }
+        const nextSnapshot = toSnapshot(state);
+        if (areSnapshotsEqual(nextSnapshot, lastSnapshot)) {
+          return;
+        }
+        lastSnapshot = nextSnapshot;
+        void writeStoredSnapshot(nextSnapshot);
+      });
+    }
+
+    registerStorageListener();
+  })();
+
+  return initializePromise;
+}
+
+export function __resetBubbleLauncherStoreForTests() {
+  fallbackStore.clear();
+  lastSnapshot = { ...DEFAULT_SNAPSHOT };
+  hydrating = false;
+  initializePromise = null;
+  if (unsubscribePersist) {
+    unsubscribePersist();
+    unsubscribePersist = null;
+  }
+  storageListenerRegistered = false;
+  if (storageChangeListener && typeof chrome !== 'undefined' && chrome.storage?.onChanged?.removeListener) {
+    chrome.storage.onChanged.removeListener(storageChangeListener);
+  }
+  storageChangeListener = null;
+  useBubbleLauncherStore.setState({
+    activeBubble: null,
+    hydrated: false,
+    conversationFolderShortcuts: []
+  });
+}

--- a/tests/runAll.ts
+++ b/tests/runAll.ts
@@ -5,6 +5,7 @@ async function runSequentially() {
   await import('./conversationIngestion.spec');
   await import('./jobScheduler.spec');
   await import('./backgroundMessaging.spec');
+  await import('./shared/bubbleLauncherStore.spec');
 }
 
 runSequentially()

--- a/tests/shared/bubbleLauncherStore.spec.ts
+++ b/tests/shared/bubbleLauncherStore.spec.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+
+import {
+  __resetBubbleLauncherStoreForTests,
+  initializeBubbleLauncherStore,
+  useBubbleLauncherStore
+} from '@/shared/state/bubbleLauncherStore';
+
+const STORAGE_KEY = 'ai-companion:bubble-launcher:v1';
+
+interface ChromeStorageChange {
+  oldValue?: unknown;
+  newValue?: unknown;
+}
+
+type ChromeStorageListener = (changes: Record<string, ChromeStorageChange>, areaName: string) => void;
+
+function createChromeMock() {
+  const storageState: Record<string, unknown> = {};
+  const listeners = new Set<ChromeStorageListener>();
+
+  const local = {
+    async get(key: string) {
+      return { [key]: storageState[key] };
+    },
+    async set(items: Record<string, unknown>) {
+      const changes: Record<string, ChromeStorageChange> = {};
+      for (const [key, value] of Object.entries(items)) {
+        changes[key] = { oldValue: storageState[key], newValue: value };
+        storageState[key] = value;
+      }
+      listeners.forEach((listener) => listener(changes, 'local'));
+    }
+  } as unknown as chrome.storage.StorageArea;
+
+  const storage = {
+    local,
+    onChanged: {
+      addListener(listener: ChromeStorageListener) {
+        listeners.add(listener);
+      },
+      removeListener(listener: ChromeStorageListener) {
+        listeners.delete(listener);
+      }
+    }
+  } as unknown as typeof chrome.storage;
+
+  const chromeMock: any = {
+    storage,
+    runtime: { lastError: undefined },
+    __storageState: storageState
+  };
+
+  return chromeMock;
+}
+
+const previousChrome = (globalThis as any).chrome;
+const chromeMock: any = createChromeMock();
+Object.defineProperty(globalThis, 'chrome', {
+  configurable: true,
+  writable: true,
+  value: chromeMock
+});
+
+type AsyncTest = [name: string, execute: () => Promise<void>];
+
+async function runAfterPersist() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const tests: AsyncTest[] = [
+  [
+    'hydrates folder shortcuts from chrome.storage.local',
+    async () => {
+      chromeMock.__storageState[STORAGE_KEY] = {
+        conversationFolderShortcuts: [
+          { id: 'folder-1', name: 'First', depth: 0, favorite: true },
+          { id: 'folder-2', name: 'Nested', depth: 1, favorite: false }
+        ]
+      };
+
+      await initializeBubbleLauncherStore();
+
+      const state = useBubbleLauncherStore.getState();
+      assert.equal(state.hydrated, true);
+      assert.deepEqual(state.conversationFolderShortcuts, [
+        { id: 'folder-1', name: 'First', depth: 0, favorite: true },
+        { id: 'folder-2', name: 'Nested', depth: 1, favorite: false }
+      ]);
+    }
+  ],
+  [
+    'persists folder shortcuts when updated',
+    async () => {
+      delete chromeMock.__storageState[STORAGE_KEY];
+
+      await initializeBubbleLauncherStore();
+
+      useBubbleLauncherStore
+        .getState()
+        .setConversationFolderShortcuts([
+          { id: 'folder-1', name: 'First', depth: 0, favorite: true }
+        ]);
+
+      await runAfterPersist();
+
+      assert.deepEqual(chromeMock.__storageState[STORAGE_KEY], {
+        conversationFolderShortcuts: [{ id: 'folder-1', name: 'First', depth: 0, favorite: true }]
+      });
+    }
+  ],
+  [
+    'applies external chrome.storage updates to the cache',
+    async () => {
+      chromeMock.__storageState[STORAGE_KEY] = {
+        conversationFolderShortcuts: [{ id: 'folder-1', name: 'Initial', depth: 0, favorite: false }]
+      };
+
+      await initializeBubbleLauncherStore();
+
+      await chrome.storage.local.set({
+        [STORAGE_KEY]: {
+          conversationFolderShortcuts: [
+            { id: 'folder-1', name: 'Initial', depth: 0, favorite: true },
+            { id: 'folder-2', name: 'Second', depth: 1, favorite: false }
+          ]
+        }
+      });
+
+      await runAfterPersist();
+
+      const state = useBubbleLauncherStore.getState();
+      assert.deepEqual(state.conversationFolderShortcuts, [
+        { id: 'folder-1', name: 'Initial', depth: 0, favorite: true },
+        { id: 'folder-2', name: 'Second', depth: 1, favorite: false }
+      ]);
+    }
+  ]
+];
+
+async function run() {
+  let hasFailure = false;
+
+  for (const [name, execute] of tests) {
+    __resetBubbleLauncherStoreForTests();
+    try {
+      await execute();
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      hasFailure = true;
+      console.error(`✖ ${name}`);
+      console.error(error);
+    }
+  }
+
+  __resetBubbleLauncherStoreForTests();
+
+  if (previousChrome === undefined) {
+    delete (globalThis as any).chrome;
+  } else {
+    Object.defineProperty(globalThis, 'chrome', {
+      configurable: true,
+      writable: true,
+      value: previousChrome
+    });
+  }
+
+  if (hasFailure) {
+    process.exitCode = 1;
+  }
+}
+
+await run();


### PR DESCRIPTION
## Summary
- persist conversation folder shortcuts to chrome.storage.local and hydrate the bubble launcher store so dock favourites render immediately
- initialise the bubble launcher cache before mounting the sidebar UI and document the workflow updates in retrofit.md and the manual regression guide
- add a bubbleLauncherStore unit test and wire it into the test runner for regression coverage

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a5ca26e48333b569c1e06107be42