### PR TITLE
feat: allow dismissing guides

### DIFF
--- a/docs/testing/manual-regression.md
+++ b/docs/testing/manual-regression.md
@@ -34,6 +34,7 @@ Execute on `chat.openai.com`, then repeat on `chatgpt.com`.
    - Pin and bookmark buttons on each card toggle state and counts without requiring a refresh.
 3. Use “Open conversation” on the pinned chat and confirm a new tab targets the correct conversation id.
 4. Scroll to the placeholder sections at the bottom of the popup and ensure they still show the “arrive soon” copy for bookmarks, pinned chats, and recent activity (regressions here can break expectations for upcoming features).
+5. Controleer in het nieuwe blok “Gidsen & updates” dat de lijst verschijnt, dat “Bekijken” een nieuw tabblad opent en dat het “Markeer als bekeken”-label synchroniseert met de dashboardkaart.
 
 ## Dashboard / options regression
 
@@ -45,6 +46,7 @@ Execute on `chat.openai.com`, then repeat on `chatgpt.com`.
    - Controleer dat de gidsen binnen twee seconden laden en dat de kaart geen foutmelding toont.
    - Klik “Bekijken” bij een gids en verifieer dat er een nieuw tabblad opent op de Guideflow-URL.
    - Open `chrome://extensions` → “Service worker” console en bevestig dat er een logregel `telemetry event` verschijnt met `event: "guide-opened"` en het juiste `guideId`.
+   - Zet “Markeer als bekeken” aan voor een gids, herlaad de pagina en bevestig dat de badge “Bekeken” zichtbaar blijft. Zet de toggle daarna weer uit en controleer dat de gids opnieuw als ongelezen verschijnt.
 4. In de conversation section:
    - Verify the folder tree renders and the active conversations appear in the table with correct message/word/character counts.
    - Toggle the pinned filter to “Pinned only” and ensure only the pinned conversation remains. Switch back to “All”.

--- a/retrofit.md
+++ b/retrofit.md
@@ -78,6 +78,11 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
    - ✅ `useBubbleLauncherStore` hydrateert via `chrome.storage.local` (`initializeBubbleLauncherStore`) en cachet de geflatteerde mapstructuur, zodat favorieten onmiddellijk zichtbaar zijn bij heropenen.
    - ✅ QA: Nieuwe regressiestap voor dock-favorieten toegevoegd aan [`docs/testing/manual-regression.md`](docs/testing/manual-regression.md#bookmark--pin-workflow).
 
+8. **Gidsstatus synchroniseren** –
+   - ✅ `useSettingsStore` bewaart `dismissedGuideIds` en synchroniseert wijzigingen tussen popup, options en content.
+   - ✅ Options- en popup-surfaces tonen een “Markeer als bekeken”-toggle inclusief badge, persistente status en omkeeractie.
+   - ✅ QA: Regressiegids uitgebreid met stappen voor gids-toggles in zowel dashboard als popup.
+
 ## Prioriteiten en stappen per featuregroep
 
 
@@ -205,5 +210,6 @@ Dit document is het leidende werkdossier om de `example/example/1`-mockups in li
 | 2025-10-16 | _pending_ | Onboarding & gidsen | Guides dataset + Zod-validatie toegevoegd; npm run lint/test uitgevoerd |
 | 2025-10-17 | _pending_ | Onboarding & gidsen | Options-gidsenkaart + telemetry event logging; npm run lint/test/build uitgevoerd |
 | 2025-10-18 | _pending_ | Pin- & bulkbeheer | Dock-favorieten cache hydrateert via chrome.storage; unit test bubbleLauncherStore + lint/test/build uitgevoerd |
+| 2025-10-18 | _pending_ | Onboarding & gidsen | Guides “Markeer als bekeken”-toggles + storage sync; npm run lint/test/build uitgevoerd |
 | _vul in_ | _vul in_ | _vul in_ | _korte notitie over tests, regressies, follow-up_ |
 

--- a/src/shared/hooks/useGuideResources.ts
+++ b/src/shared/hooks/useGuideResources.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+
+import { parseGuidesFile, type GuideResource } from '@/core/models/guides';
+
+export interface GuideResourcesState {
+  status: 'idle' | 'loading' | 'loaded' | 'error';
+  guides: GuideResource[];
+  error?: string | null;
+}
+
+export function resolveGuidesAssetUrl(): string {
+  const chromeApi = (globalThis as unknown as { chrome?: typeof chrome }).chrome;
+  if (chromeApi?.runtime?.getURL) {
+    return chromeApi.runtime.getURL('guides.json');
+  }
+  return '/guides.json';
+}
+
+export async function openGuideResource(url: string): Promise<void> {
+  const chromeApi = (globalThis as unknown as { chrome?: typeof chrome }).chrome;
+
+  if (chromeApi?.tabs?.create) {
+    await new Promise<void>((resolve, reject) => {
+      chromeApi.tabs.create({ url, active: true }, () => {
+        const lastError = chromeApi.runtime?.lastError;
+        if (lastError) {
+          reject(new Error(lastError.message));
+          return;
+        }
+        resolve();
+      });
+    });
+    return;
+  }
+
+  if (typeof window !== 'undefined') {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}
+
+export function useGuideResources(): GuideResourcesState {
+  const [state, setState] = useState<GuideResourcesState>({ status: 'idle', guides: [] });
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function loadGuides() {
+      setState({ status: 'loading', guides: [] });
+      try {
+        const response = await fetch(resolveGuidesAssetUrl(), {
+          signal: controller.signal,
+          cache: 'no-cache'
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to load guides (${response.status})`);
+        }
+
+        const payload = await response.json();
+        const parsed = parseGuidesFile(payload);
+
+        if (cancelled) {
+          return;
+        }
+
+        setState({ status: 'loaded', guides: parsed.guides });
+      } catch (error) {
+        if (cancelled || controller.signal.aborted) {
+          return;
+        }
+
+        setState({
+          status: 'error',
+          guides: [],
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    void loadGuides();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
+  return state;
+}

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -51,7 +51,22 @@
     "loadingSettings": "Loading settings…",
     "sidebarToggleLabel": "Chat sidebar",
     "sidebarToggleOn": "Enabled",
-    "sidebarToggleOff": "Disabled"
+    "sidebarToggleOff": "Disabled",
+    "guides": {
+      "heading": "Guides & updates",
+      "description": "Discover quick tips to make the most of the extension.",
+      "loading": "Loading guides…",
+      "empty": "You’re all caught up.",
+      "error": "Guides could not be loaded. Open the dashboard to retry later.",
+      "viewedBadge": "Viewed",
+      "openCta": "View",
+      "openAria": "Open guide {{title}}",
+      "opening": "Opening…",
+      "markViewed": "Mark “{{title}}” as viewed",
+      "markViewedAria": "Mark guide {{title}} as viewed",
+      "markUnviewed": "Restore “{{title}}”",
+      "markUnviewedAria": "Restore guide {{title}}"
+    }
   },
   "options": {
     "heading": "AI Companion Dashboard",
@@ -93,7 +108,12 @@
       "estimatedTime": "{{minutes}} min read",
       "openCta": "View",
       "openAria": "Open guide {{title}}",
-      "opening": "Opening…"
+      "opening": "Opening…",
+      "markViewed": "Mark “{{title}}” as viewed",
+      "markViewedAria": "Mark guide {{title}} as viewed",
+      "markUnviewed": "Restore “{{title}}”",
+      "markUnviewedAria": "Restore guide {{title}}",
+      "viewedBadge": "Viewed"
     },
     "favoriteFolder": "Mark as favorite",
     "unfavoriteFolder": "Remove favorite",

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -51,7 +51,22 @@
     "loadingSettings": "Instellingen laden…",
     "sidebarToggleLabel": "Chat-zijbalk",
     "sidebarToggleOn": "Ingeschakeld",
-    "sidebarToggleOff": "Uitgeschakeld"
+    "sidebarToggleOff": "Uitgeschakeld",
+    "guides": {
+      "heading": "Gidsen & updates",
+      "description": "Ontdek snelle tips om alles uit de extensie te halen.",
+      "loading": "Gidsen laden…",
+      "empty": "Je bent weer helemaal bij.",
+      "error": "Gidsen konden niet worden geladen. Open het dashboard om het later opnieuw te proberen.",
+      "viewedBadge": "Bekeken",
+      "openCta": "Bekijken",
+      "openAria": "Open gids {{title}}",
+      "opening": "Bezig…",
+      "markViewed": "Markeer “{{title}}” als bekeken",
+      "markViewedAria": "Markeer gids {{title}} als bekeken",
+      "markUnviewed": "Herstel “{{title}}”",
+      "markUnviewedAria": "Herstel gids {{title}}"
+    }
   },
   "options": {
     "heading": "AI Companion Dashboard",
@@ -93,7 +108,12 @@
       "estimatedTime": "{{minutes}} min lezen",
       "openCta": "Bekijken",
       "openAria": "Open gids {{title}}",
-      "opening": "Bezig…"
+      "opening": "Bezig…",
+      "markViewed": "Markeer “{{title}}” als bekeken",
+      "markViewedAria": "Markeer gids {{title}} als bekeken",
+      "markUnviewed": "Herstel “{{title}}”",
+      "markUnviewedAria": "Herstel gids {{title}}",
+      "viewedBadge": "Bekeken"
     },
     "favoriteFolder": "Markeren als favoriet",
     "unfavoriteFolder": "Favoriet verwijderen",


### PR DESCRIPTION
## Summary
- persist guide dismissal state in the shared settings store and hydrate it from chrome.storage
- add mark-as-viewed toggles to the options card and popup using the shared guide loader
- document the new QA coverage for guide toggles and log the retrofit progress

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2ad4c37dc8333b270698051d2a2a6