### PR TITLE
docs: align retrofit tracker with pariteit-plus roadmap

### DIFF
--- a/docs/handbook/retrofit-tracker.md
+++ b/docs/handbook/retrofit-tracker.md
@@ -1,87 +1,108 @@
 # Retrofit tracker
 
-_Last reviewed: 2024-10-20_
+_Last reviewed: 2025-02-14_
 
-Dit werkdocument houdt bij hoe de huidige extensie zich verhoudt tot de oorspronkelijke conceptmockups. Gebruik het tijdens planningssessies om delivered flows, lopende iteraties en resterende ontwerptaken scherp te houden. Synchroniseer wijzigingen met [`docs/handbook/product-roadmap.md`](./product-roadmap.md) en de regressiegids.
+Dit dossier koppelt de bestaande extensie aan de nieuwe **privacy-first, local-first** roadmap. Gebruik het om pariteit met ChatGPT Toolbox te meten, plus-features te plannen en QA/retrofit-besluiten te loggen. Synchroniseer wijzigingen steeds met [`docs/handbook/product-roadmap.md`](./product-roadmap.md), de regressiegids en relevante ADR's.
 
-## Samenvatting featuregroepen
-| Featuregroep | Scope | Status | Laatste update |
+## Overzicht pariteit → plus
+| Featuregroep | Kernscope | Status | Laatste update |
 | --- | --- | --- | --- |
-| Conversatiedock & bubbels | Shadow-root host, bubbledock rechts, sneltoetsen, history/actions/prompts/guides/media tabs | ✅ Gereed | 2024-10-20 – main branch |
-| Pin- & bulkbeheer | Pinned weergaves, bulk selectie, verplaatsdialogen, favoriete mappen cache | ✅ Gereed | 2024-10-20 – main branch |
-| Bladwijzers & contextmenu | Bubbelacties, inline notitiemodaal, custom contextmenu met toasts en popup-sync | ✅ Gereed | 2024-10-20 – main branch |
-| Promptbibliotheek & ketens | GPT- en promptbeheer, keten-editor met variabelen, launcher integratie, cancel flow | ✅ Gereed | 2024-10-20 – main branch |
-| Gespreksanalyse & export | MiniSearch index, export jobs (JSON/TXT), dashboard jobtable | 🚧 Iteratie | 2025-10-05 – status badges tonen retry/backoff |
-| Media & audio | Instellingenscherm met toggles, preview overlay, modal skeletons | 💤 Placeholder | 2024-10-20 – functionaliteit simulatie, geen echte audio |
-| Richting & instellingen | Taalwissel, RTL toggle, dock toggle synchronisatie | ✅ Gereed | 2024-10-20 – main branch |
-| Guides & onboarding | Guides dataset, popup/options kaart, content modal, telemetry logging | ✅ Gereed | 2024-10-20 – main branch |
-| Internationalisatie | EN/NL lokalisatie, RTL ondersteuning, settings-store sync | 🚧 Iteratie | 2024-10-20 – extra talen gepland |
-| Account & premium | Auth-manager, premium vlag, entitlement storage, billing flows | 📝 Ontwerp | Nog te plannen |
+| Gespreksbeheer & mappen | Onbeperkte mappen/submappen, GPT-koppeling, drag & drop, pinned folders, bulk verplaatsing | 🟥 Gap – ontwerp | 2025-02-14 – roadmap geaccepteerd |
+| Professionele zijbalk | History search (<150 ms), pin/hide, bulkacties, collapse GPTs, undo flows | 🟧 Gap – analyse | 2025-02-14 – zoekindex benchmark lopend |
+| Chat pinning & bulkacties | Pin/unpin met shortcut, bulkselectie 500+, exact filters, persistente state | 🟧 Gap – analyse | 2025-02-14 – Dexie schema review |
+| Promptbibliotheek | CRUD, tagging, versies, favorieten, `//` launcher ≤50 ms | 🟥 Gap – ontwerp | 2025-02-14 – trigger specs klaar |
+| Prompt-chaining (10 stappen) | Placeholder validatie, `..` launcher, batch-run, tussenoutput logging | 🟥 Gap – ontwerp | 2025-02-14 – DSL uitgewerkt |
+| Mediagalerij | Raster met prompt/gen/seed metadata, virtuele scroll, ZIP export ≤3 s | 🟥 Gap – ontwerp | 2025-02-14 – datamodel geschetst |
+| Audio-export | MP3-pijplijn, voice-presets (free/premium), metadata/ID3, queue | 🟥 Gap – ontwerp | 2025-02-14 – encoder onderzoek |
+| UI/UX thema & i18n | Meertaligheid incl. RTL, dynamische thema's, woord/tekenteller | 🟨 Iteratie | 2025-02-14 – thema tokens gereviseerd |
+| Privacy & sync | IndexedDB-only content, opt-in AES-GCM promptsync, netwerkverificatie | 🟨 Iteratie | 2025-02-14 – encryptieplan opgesteld |
+| Chaining++ (templates/branching/analytics) | Conditionele nodes, sjablonen, runtime-metrics, promptkoppeling | 🟦 Plus backlog | Nog te plannen |
+| Agentische tools & SDK | Web/file/computer use, Responses API, extensible SDK | 🟦 Plus backlog | Nog te plannen |
+| Enterprise & Azure integraties | SSO/RBAC, auditlog, Key Vault, App Insights, Content Safety | 🟦 Plus backlog | Nog te plannen |
 
-> **Onderhoudstip** – noteer datum + commit (kort hash) in de kolom “Laatste update” zodra een featuregroep nieuw werk ontvangt. Voeg extra rijen toe wanneer een featuregroep wordt opgesplitst.
+> **Legenda** – 🟥 ontwerp nodig · 🟧 analyse/technische spikes · 🟨 actieve iteratie · 🟩 gereed · 🟦 toekomstige pluslaag.
 
-## Context & huidige stand
-- Alle runtime oppervlakken zijn herschreven rond de rechter dock (`src/content/ui-root.tsx`). Links geplaatste panelen uit de oude mockups zijn uitgefaseerd.
-- De promptlauncher (`src/content/textareaPrompts.ts`) en composer counters draaien naast elkaar binnen dezelfde shadow-root en delen stores met popup/options.
-- Popup en dashboard gebruiken gedeelde hooks (`useRecentConversations`, `useGuideResources`, `useSettingsStore`) zodat statuswijzigingen realtime blijven.
-- Background worker verzorgt contextmenu triggers, auth-status, exportjobs en eventlogging. Nieuwe jobtypes registreren zich via `createJobScheduler`.
+## Samenvatting voortgang
+- Fase 1 (Pariteit MVP) is in architectuurfase: storage, search en launcher-scenario's zijn gespecificeerd maar niet gebouwd.
+- RTL/thema-herziening is in uitvoering; andere UI-pariteitsfeatures wachten op componentrefactor.
+- Versleutelde sync en audio/media pipelines vereisen service-worker uitbreidingen (nog niet gepland).
+- Pluslaag (branching, agent tools, enterprise) blijft op backlog totdat pariteit bereikt is.
 
-## Werkafspraken
-1. **Scope prioriteren** – Houd Phase 3-items (jobs/export/search) uit de roadmap als primaire focus. Nieuwe ideeën krijgen eerst een ADR of backlog entry voor ze in dit bestand landen.
-2. **Documentatie spiegelen** – Werk bij:
-   - [`docs/handbook/product-roadmap.md`](./product-roadmap.md) voor strategische fases.
-   - [`docs/handbook/manual-regression-checklist.md`](./manual-regression-checklist.md) voor QA-stappen.
-   - [`docs/handbook/adr-*.md`](./) voor architectuur- of privacybesluiten.
-3. **Log voortgang** – Gebruik het logboek onderaan voor afgeronde tranches. Vermeld datum, commit, uitgevoerde checks (lint/test/build) en openstaande follow-ups.
-4. **Featurepariteit bewaken** – Wanneer mockups van de `example/example/1` map afwijken van de implementatie, noteer het hier inclusief motivatie (bijv. technische beperking of UX-beslissing).
+## Kernprincipes (bevestigd)
+1. **Local-first privacy** – chats in IndexedDB, alleen versleutelde promptsync optioneel.
+2. **Sneller dan scrollen** – exacte filters + minisearch index, P95 <150 ms.
+3. **Herbruikbaarheid** – `//` voor prompts, `..` voor chains, placeholders en variabelen.
+4. **Cross-browser** – Chrome/Edge basiskanaal, Firefox-compatibiliteit in fase 2.
 
-## Actieve iteraties & opvolgers
-- **Export & jobs UI polish**
-  - [x] Status-badges uitbreiden met retry count en volgende backoff tijd.
-  - [ ] Filterpaneel toevoegen aan het jobs-overzicht (status/type).
-  - [ ] Toast naar popup sturen wanneer een geplande export voltooid is.
-- **Zoekindex worker**
-  - [ ] MiniSearch-index rebuild verplaatsen naar een worker (`SharedWorker`/`ServiceWorker`) zodat grote datasets non-blocking zijn.
-  - [ ] Progress events naar de dashboard history sectie sturen wanneer reindexing plaatsvindt.
-- **Contextmenu focus management**
-  - [ ] Actieve element bij openen bewaren en na sluiting herstellen.
-  - [ ] Roving tabindex/arrow-key navigatie toevoegen voor toekomstige extra items.
-- **Internationalisatie uitbreiding**
-  - [ ] Automatische taalkeuze baseren op ChatGPT `lang`-attribuut met opt-out in instellingen.
-  - [ ] Extra talen genereren (DE, ES, FR) via script en regressies opnemen in QA.
+## Actieve iteraties & deliverables
+- **Search & sidebar spike**
+  - [ ] Dexie-schema uitbreiden met `folders` en `folder_items` tabellen.
+  - [ ] MiniSearch indexeren op titel, tags, map-hiërarchie; meten latency bij 10k berichten.
+  - [ ] UI-wireframes voor zijbalk pin/hide/collapse flows uitwerken.
+- **Launcher ervaring**
+  - [ ] Promptlauncher UX (keyboard-first) definiëren; fuzzy search testen.
+  - [ ] Chain DSL parser (placeholders, [[step.output]]) prototypen.
+  - [ ] Inline triggers `//` en `..` integreren met bestaande composer store.
+- **Privacy & sync voorbereiding**
+  - [ ] AES-GCM encryptieproof-of-concept in service worker met PBKDF2.
+  - [ ] IndexedDB audit: bevestig geen network egress van chatinhoud.
+  - [ ] Documenteer verificatiestappen voor QA (DevTools Application/Network).
+- **Theming & i18n**
+  - [ ] CSS variabelen voor light/dark/high-contrast invoeren.
+  - [ ] RTL smoketests uitvoeren in content, popup en options.
+  - [ ] Locale switcher koppelen aan instellingenstore met persistente voorkeur.
 
-## Definition of done per featuregroep
-Gebruik onderstaande checklists wanneer je aan de respectieve featuregroepen werkt.
+## Definition of done per groep
+### Gespreksbeheer & mappen
+- [ ] CRUD-operaties O(1) in Dexie, inclusief nested structuren.
+- [ ] Mapwissel rendeert ≤50 ms bij 2.000 conversaties (Profiler-rapport).
+- [ ] Pinned folders staan bovenaan en zijn drag-and-drop reorderbaar.
+- [ ] End-to-end: aanmaken → verplaatsen → zoeken → exporteren (TXT/JSON) geslaagd.
 
-### Dock & bubbels
-- [ ] Alle bubbelknoppen keyboard- en screenreader-toegankelijk (labels + aria-pressed).
-- [ ] Store synchronisatie (`useBubbleLauncherStore`) hydrateert via `chrome.storage` en zet default waarden zonder flikkering.
-- [ ] Pattern modal en instructie-overlays resetten hun state na sluiting.
+### Professionele zijbalk & pinnen
+- [ ] Zoekopdrachten returneren <150 ms bij dataset van 10k berichten.
+- [ ] Bulkselectie ondersteunt 500 items met undo + toastfeedback.
+- [ ] Collapse toggle voor GPT-sectie persisteert in instellingen.
+- [ ] Pin/unpin via UI en sneltoets binnen 50 ms feedback, persistent over reloads.
 
-### Promptbibliotheek & ketens
-- [ ] GPT/prompt CRUD slaagt en updates zijn zichtbaar zonder reload.
-- [ ] Promptketen-runner ondersteunt annuleren en foutmeldingen met toasts.
-- [ ] Variabelen in ketens zijn uniek en valideren met duidelijke foutcopy.
+### Promptbibliotheek & chaining
+- [ ] Prompt CRUD met tags, versies, favorieten en encrypted opslag.
+- [ ] `//` launcher toont ≤50 ms, ondersteunt fuzzy search, behoudt focus.
+- [ ] Chains tot 10 stappen met placeholders, batch-run, annuleren en foutmeldingen.
+- [ ] `..` launcher start chain met ingevulde variabelen; export/import JSON schema gevalideerd.
 
-### Bladwijzers & contextmenu
-- [ ] Bookmark modal toont preview, notitieveld en saved state.
-- [ ] Contextmenu sluit bij scroll, Escape en dock-hide. Disabled states tonen helpercopy.
-- [ ] Popup/Options synchroniseren bookmarks en laten meest recente bovenaan zien.
+### Media & audio
+- [ ] Mediagalerij rendert 1.000 thumbnails <300 ms (virtuele scroll bewezen).
+- [ ] ZIP export (100 items) voltooit ≤3 s en bevat metadata CSV.
+- [ ] Audio-render queue produceert MP3 <4 s per 1.000 tekens, met ID3-tags en voice metadata.
 
-### Export & jobs
-- [ ] Jobs schrijven naar Dexie, herstellen na worker herstart en tonen attempts/backoff in UI.
-- [ ] Exports produceren geldige JSON/TXT bestanden en loggen fouten in de service-worker console.
-- [ ] Dashboard jobs tabel ondersteunt sorteren/filteren zonder layout shift.
+### Privacy & sync
+- [ ] IndexedDB bevat volledige chatinhoud; geen network requests met content payload.
+- [ ] Optionele sync encrypt prompts met AES-GCM 256; sleutels beheerd via OS keystore/passphrase.
+- [ ] DevTools verificatiescripts en QA-checklist bijgewerkt.
 
-### Media workspace (placeholder)
-- [ ] Instellingen toggles synchroniseren met `useMediaStore` en `chrome.storage.local`.
-- [ ] Preview overlay sluit met Escape en herstelt focus naar de trigger.
-- [ ] Modalcomponenten gebruiken gedeelde UI zodat toekomstige echte audio-implementaties drop-in zijn.
+### Pluslaag (branching/agent/enterprise)
+- [ ] Conditionele nodes, sjablonen en analytics dashboards (looptijd, success rate, tokens).
+- [ ] Agents SDK levert web/file/computer use capabilities met auditeerbare logging.
+- [ ] Enterprise SSO/RBAC, auditlog en Azure integraties met Key Vault + Content Safety.
+
+## Testprompts & QA-scripts
+Gebruik onderstaande scenario's als regressie-anker zodra features landen.
+- **Chains** – "Samenvat→Outline→Draft" met 1.000 woorden invoer.
+- **Launchers** – `//` selecteert "Bug Triage Prompt"; `..` start keten uit vorige punt.
+- **Mappen/pinnen** – Maak "Release 1" → "Tests", verplaats 200 chats, pin "Kickoff", voer exacte zoekquery `title:"Q3 Roadmap" AND tag:finance`.
+- **Mediagalerij** – Filter op `prompt:"brandkleur"`, exporteer 50 items als ZIP + seeds CSV.
+- **Audio** – Render laatste antwoord als MP3 (voice `Female_03`) met ID3-tags.
+- **Privacy** – DevTools Application→IndexedDB check + Network tab (geen content uploads).
+
+## Documentatie & synchronisatie
+- Houd roadmap en ADR's in sync met beslissingen uit deze tracker.
+- Noteer afwijkingen van mockups (in `docs/design/` zodra beschikbaar) inclusief motivatie.
+- QA-resultaten loggen in [`manual-regression-checklist.md`](./manual-regression-checklist.md) en verwijs vanuit logboek.
 
 ## Logboek
-| Datum | Commit | Featuregroep(en) | Notities |
+| Datum | Commit | Scope | Notities |
 | --- | --- | --- | --- |
-| 2024-10-20 | _pending_ | Documentatie | Mapstructuur geherorganiseerd naar `docs/handbook/`, roadmap/regressie/ADR’s geactualiseerd, contextmenu playbook bijgewerkt. |
-| 2025-10-05 | _pending_ | Export & jobs UI | Status-badges tonen retry/backoff details; `npm run lint`. |
+| 2025-02-14 | _pending_ | Documentatie | Tracker herschreven volgens pariteit→plus roadmap; statuslegenda toegevoegd; acties voor search/launcher/privacy gepland. |
 
 Voeg nieuwe regels toe met `YYYY-MM-DD | commit | scope | details` en noteer welke QA (lint/test/build/manual) is uitgevoerd.


### PR DESCRIPTION
## Summary
- rewrite the retrofit tracker around the new privacy-first ChatGPT Toolbox parity roadmap
- capture feature status, DoD checklists, and active iterations for search, launcher, privacy, and theming
- document QA prompts and synchronization expectations for the updated scope

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e2bf9ecc688333855509c58d6247f7