### PR TITLE
feat: add folder item pivot for Dexie schema

### DIFF
--- a/docs/handbook/adr-20240215-auth-and-data-model.md
+++ b/docs/handbook/adr-20240215-auth-and-data-model.md
@@ -1,6 +1,6 @@
 # ADR 2024-02-15 — Auth & data model richting premiumuitrol
 
-_Last reviewed: 2024-10-20_
+_Last reviewed: 2025-02-15_
 
 ## Context
 Premiumfeatures vragen om een betrouwbare identiteit, entitlementvalidatie en zorgvuldig databeheer. De huidige extensie draait volledig client-side maar moet voorbereid zijn op:
@@ -17,7 +17,7 @@ We hanteren een client-first aanpak met een lichte authlaag en een uitbreidbaar 
 - Tokens leven uitsluitend in geheugen (service worker scope). Er is geen refresh flow of opslag op schijf; dit voorkomt dat verouderde tokens lekken maar vereist backendondersteuning zodra echte sessies worden opgezet.
 
 ### Data model
-- Dexie (`src/core/storage/db.ts`) bevat tabellen voor gesprekken, berichten, prompts, GPT’s, folders, bookmarks, instellingen en de jobqueue. De structuur is ontworpen zodat toekomstige sync/backups extra tabellen kunnen toevoegen zonder brekende migraties.
+- Dexie (`src/core/storage/db.ts`) bevat tabellen voor gesprekken, berichten, prompts, GPT’s, folders, folder-items, bookmarks, instellingen en de jobqueue. `folder_items` fungeert als pivot tussen mappen en inhoud zodat bulkacties en hiërarchische zoekindexen meerdere itemtypes kunnen ondersteunen zonder duplicatie. De structuur blijft ontworpen zodat toekomstige sync/backups extra tabellen kunnen toevoegen zonder brekende migraties.
 - Encryptiehelpers bestaan (`core/storage/service.ts`) maar zijn niet geactiveerd. Zolang we lokaal blijven draaien, volstaat dit; zodra server syncs live gaan moeten we payloads versleutelen voordat ze het apparaat verlaten.
 - Entitlements worden momenteel niet opgeslagen. Premium UI gebruikt runtime auth-status; wanneer backendkoppeling komt, voegen we een `accounts`-tabel toe zodat entitlementwijzigingen offline kunnen worden afgedwongen.
 

--- a/docs/handbook/manual-regression-checklist.md
+++ b/docs/handbook/manual-regression-checklist.md
@@ -8,6 +8,7 @@ Use this guide for every release candidate that touches the popup, dashboard/opt
 1. **Browser profile**
    - Load the unpacked extension in a Chromium-based browser.
    - Clear extension storage (`chrome://extensions` → Inspect views → Application → Clear storage) unless migration testing is in scope.
+   - For schema migrations: delete the `AICompanionDB` database under **IndexedDB** and reload the extension to ensure the new `folders` and `folder_items` tables initialise cleanly before running tests.
 2. **ChatGPT sessions**
    - Sign in to the same ChatGPT account on both `https://chat.openai.com` and `https://chatgpt.com`.
    - Keep the UI language on English for baseline copy unless you are validating localization.

--- a/docs/handbook/product-roadmap.md
+++ b/docs/handbook/product-roadmap.md
@@ -1,6 +1,6 @@
 # AI Browser Extension — Architecture & Delivery Roadmap
 
-_Last updated: 2024-10-20_
+_Last updated: 2025-02-15_
 
 This living document combines the architectural snapshot, delivery status, and premium launch planning for the AI Browser Extension. Update it whenever shipped functionality or priorities change so contributors have a single source of truth.
 
@@ -20,7 +20,7 @@ This living document combines the architectural snapshot, delivery status, and p
 - **Background service worker** – Beheert auth-status, jobqueue met backoff, downloadexports en eventlogging. Messaging routes verbinden popup, options en content.
 
 ### State & shared services
-- **Dexie data model** – IndexedDB bevat gesprekken, berichten, prompts, GPT’s, folders, bookmarks, instellingen, jobs en metadata. Het schema laat ruimte voor toekomstige sync/back-up tabellen.
+- **Dexie data model** – IndexedDB bevat gesprekken, berichten, prompts, GPT’s, folders, folder-items, bookmarks, instellingen, jobs en metadata. De nieuwe `folder_items` pivot houdt folderlidmaatschappen van gesprekken/prompts/GPT’s bij zodat bulkacties en hiërarchische zoekindexen de juiste relatie hebben. Het schema laat ruimte voor toekomstige sync/back-up tabellen.
 - **Zoekservice** – MiniSearch-index wordt naar IndexedDB weggeschreven en bij opstart hersteld. Verwijderingen houden conversatie- en berichtdocumenten in sync.
 - **Export pipeline** – TXT/JSON exports gebruiken client-side helpers; de background handler maakt bestanden aan en start automatisch een `chrome.downloads.download` zodra de job slaagt.
 - **Authenticatie** – `AuthManager` decodeert JWT’s lokaal, deriveert premiumstatus en ondersteunt optionele JWKS caching. Signatuurvalidatie en refreshflows zijn nog niet geïmplementeerd.
@@ -41,6 +41,7 @@ This living document combines the architectural snapshot, delivery status, and p
 
 ### Near-term backlog (Phase 3 focus)
 _De onderstaande punten staan ook in het retrofitlog; markeer in beide bestanden wanneer scopes verschuiven._
+- **Search & sidebar** – _Status: in uitvoering._ Dexie-schema uitgebreid met `folder_items` pivot; volgstap is Minisearch-indexering op maphiërarchie en pins.
 - Automatische jobs dashboard vervolledigen: retry hand-offs zichtbaar maken in de UI (filterpaneel live per 2025-10-05).
 - MiniSearch-indexering naar een dedicated worker verplaatsen zodat grote datasets de content thread niet blokkeren.
 - Promptketen-runner voorzien van progress feedback en annuleringsevents naar de popup.

--- a/docs/handbook/retrofit-tracker.md
+++ b/docs/handbook/retrofit-tracker.md
@@ -39,7 +39,7 @@ De extensie evolueert naar een **volledige productiviteitssuite** bovenop ChatGP
 
 ## Actieve iteraties & deliverables
 - **Search & sidebar spike**
-  - [ ] Dexie-schema uitbreiden met `folders` en `folder_items` tabellen.
+  - [x] Dexie-schema uitbreiden met `folders` en `folder_items` tabellen.
   - [ ] MiniSearch indexeren op titel, tags, map-hiërarchie; meten latency bij 10k berichten.
   - [ ] UI-wireframes voor zijbalk pin/hide/collapse flows uitwerken.
 - **Launcher ervaring**
@@ -56,10 +56,10 @@ De extensie evolueert naar een **volledige productiviteitssuite** bovenop ChatGP
   - [ ] Locale switcher koppelen aan instellingenstore met persistente voorkeur.
 
 ## Volgende stappen
-1. [ ] Dexie-schema uitbreiden met `folders` en `folder_items` tabellen.
-   - **Prioritering** – Hoog: blokkert bulkverplaatsing, pins en zoekhiërarchie. Implementatie moet vóór Minisearch-uitbreiding klaar zijn zodat index zich op stabiele sleutels kan baseren. Schat 2 dagen werk: 1 dag schema & migratie, 1 dag API-aanpassing/seeddata.
-   - **Documentatie** – Breid `docs/handbook/adr-20240215-auth-and-data-model.md` uit met de nieuwe tabellen, relaties en migratiepad. Update `docs/handbook/product-roadmap.md` sectie "Search & sidebar" naar status "in uitvoering" zodra de migratie start. Voeg migratie-instructies toe aan `docs/handbook/manual-regression-checklist.md` (IndexedDB reset) na implementatie.
-   - **QA-notes** – Na oplevering: run `npm run lint`, `npm run test`, `npm run build`. Handmatige check: DevTools Application → IndexedDB (`folders`, `folder_items`) aanmaken/verplaatsen/verwijderen; verify geen Network POSTs met chatcontent. Documenteer bevindingen (browser, datum, dataset) in retrofit logboek en regression checklist.
+1. [x] Dexie-schema uitbreiden met `folders` en `folder_items` tabellen. _(afgerond 2025-02-15)_
+   - **Prioritering** – Gereed: schema v8 levert stabiele sleutels voor bulkacties en toekomstige Minisearch-indexering. Volgende stap is de indexuitbreiding zodat hiërarchische queries performant blijven.
+   - **Documentatie** – ADR `docs/handbook/adr-20240215-auth-and-data-model.md`, roadmap (`docs/handbook/product-roadmap.md`) en regressiegids zijn bijgewerkt met de nieuwe pivot (`folder_items`) en IndexedDB-resetinstructies.
+   - **QA-notes** – Geautomatiseerd: `npm run lint`, `npm run test`, `npm run build` (Node 20.19.0). Handmatig: bij eerstvolgende browserrun DevTools → Application → IndexedDB controleren op `folders`/`folder_items`, basis CRUD uitvoeren en netwerkverkeer inspecteren (geen chatcontent POSTs) en vastleggen in logboek/regressiechecklist.
 2. [ ] MiniSearch indexeren op titel, tags, map-hiërarchie; meten latency bij 10k berichten.
 3. [ ] UI-wireframes voor zijbalk pin/hide/collapse flows uitwerken.
 
@@ -115,5 +115,6 @@ Gebruik onderstaande scenario's als regressie-anker zodra features landen.
 | Datum | Commit | Scope | Notities |
 | --- | --- | --- | --- |
 | 2025-02-14 | _pending_ | Documentatie | Tracker herschreven volgens pariteit→plus roadmap; statuslegenda toegevoegd; acties voor search/launcher/privacy gepland. |
+| 2025-02-15 | _pending_ | Storage | Dexie v8 met `folder_items` pivot geland; folderhelpers + docs/QA-updates toegevoegd; lint/test/build uitgevoerd. |
 
 Voeg nieuwe regels toe met `YYYY-MM-DD | commit | scope | details` en noteer welke QA (lint/test/build/manual) is uitgevoerd.

--- a/src/core/models/records.ts
+++ b/src/core/models/records.ts
@@ -64,6 +64,18 @@ export interface FolderRecord {
   favorite?: boolean;
 }
 
+export type FolderItemType = 'conversation' | 'prompt' | 'gpt';
+
+export interface FolderItemRecord {
+  id: string;
+  folderId: string;
+  itemId: string;
+  itemType: FolderItemType;
+  sortIndex?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface BookmarkRecord {
   id: string;
   conversationId: string;

--- a/src/core/storage/conversations.ts
+++ b/src/core/storage/conversations.ts
@@ -1,4 +1,5 @@
 import { db } from './db';
+import { removeItemsFromFolders, setItemFolder } from './folderItems';
 import { removeConversationMetadata, syncConversationMetadata } from './syncBridge';
 import type { BookmarkRecord, ConversationRecord, MessageRecord } from '@/core/models';
 import { computeTextMetrics, sumTextMetrics } from '@/core/utils/textMetrics';
@@ -73,19 +74,34 @@ export async function getConversationOverviewById(
 
 export async function upsertConversation(input: ConversationUpsertInput) {
   const timestamp = input.updatedAt ?? nowIso();
-  const result = await db.conversations.put({
-    id: input.id,
-    title: input.title,
-    folderId: input.folderId,
-    pinned: input.pinned ?? false,
-    archived: input.archived ?? false,
-    createdAt: input.createdAt ?? timestamp,
-    updatedAt: timestamp,
-    wordCount: input.wordCount ?? 0,
-    charCount: input.charCount ?? 0
+  let result: string | number | undefined;
+  let stored: ConversationRecord | undefined;
+
+  await db.transaction('rw', db.conversations, db.folderItems, async () => {
+    result = await db.conversations.put({
+      id: input.id,
+      title: input.title,
+      folderId: input.folderId,
+      pinned: input.pinned ?? false,
+      archived: input.archived ?? false,
+      createdAt: input.createdAt ?? timestamp,
+      updatedAt: timestamp,
+      wordCount: input.wordCount ?? 0,
+      charCount: input.charCount ?? 0
+    });
+
+    stored = await db.conversations.get(input.id);
+    if (stored) {
+      await setItemFolder({
+        itemId: stored.id,
+        itemType: 'conversation',
+        folderId: stored.folderId,
+        timestamp,
+        table: db.folderItems
+      });
+    }
   });
 
-  const stored = await db.conversations.get(input.id);
   if (stored) {
     await syncConversationMetadata(stored);
   }
@@ -231,10 +247,11 @@ export async function deleteConversations(ids: string[]) {
   if (!ids.length) {
     return;
   }
-  await db.transaction('rw', db.messages, db.bookmarks, db.conversations, async () => {
+  await db.transaction('rw', db.messages, db.bookmarks, db.conversations, db.folderItems, async () => {
     await db.messages.where('conversationId').anyOf(ids).delete();
     await db.bookmarks.where('conversationId').anyOf(ids).delete();
     await db.conversations.bulkDelete(ids);
+    await removeItemsFromFolders({ itemType: 'conversation', itemIds: ids, table: db.folderItems });
   });
 
   await Promise.all(ids.map((id) => removeConversationMetadata(id)));

--- a/src/core/storage/folderItems.ts
+++ b/src/core/storage/folderItems.ts
@@ -1,0 +1,104 @@
+import type { Table } from 'dexie';
+
+import { db } from './db';
+import type { FolderItemRecord, FolderItemType } from '@/core/models';
+
+export type { FolderItemType } from '@/core/models';
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function resolveTable(table?: Table<FolderItemRecord, string>) {
+  return table ?? db.folderItems;
+}
+
+function normalizeFolderId(folderId?: string | null) {
+  const trimmed = folderId?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+export interface SetItemFolderOptions {
+  itemId: string;
+  itemType: FolderItemType;
+  folderId?: string | null;
+  timestamp?: string;
+  table?: Table<FolderItemRecord, string>;
+}
+
+export async function setItemFolder({
+  itemId,
+  itemType,
+  folderId,
+  timestamp,
+  table
+}: SetItemFolderOptions) {
+  const folderItems = resolveTable(table);
+  const normalizedFolderId = normalizeFolderId(folderId);
+  const existing = await folderItems
+    .where('[itemType+itemId]')
+    .equals([itemType, itemId])
+    .first();
+
+  if (!normalizedFolderId) {
+    if (existing) {
+      await folderItems.delete(existing.id);
+    }
+    return;
+  }
+
+  const nextTimestamp = timestamp ?? nowIso();
+  if (existing) {
+    const updates: Partial<FolderItemRecord> = {
+      updatedAt: nextTimestamp
+    };
+    if (existing.folderId !== normalizedFolderId) {
+      updates.folderId = normalizedFolderId;
+    }
+    await folderItems.update(existing.id, updates);
+    return;
+  }
+
+  await folderItems.add({
+    id: crypto.randomUUID(),
+    folderId: normalizedFolderId,
+    itemId,
+    itemType,
+    createdAt: nextTimestamp,
+    updatedAt: nextTimestamp
+  });
+}
+
+export interface RemoveItemsFromFoldersOptions {
+  itemType: FolderItemType;
+  itemIds: string[];
+  table?: Table<FolderItemRecord, string>;
+}
+
+export async function removeItemsFromFolders({
+  itemType,
+  itemIds,
+  table
+}: RemoveItemsFromFoldersOptions) {
+  if (!itemIds.length) {
+    return;
+  }
+
+  const folderItems = resolveTable(table);
+  const compoundKeys = itemIds.map((itemId) => [itemType, itemId] as [FolderItemType, string]);
+  await folderItems.where('[itemType+itemId]').anyOf(compoundKeys).delete();
+}
+
+export interface RemoveFoldersOptions {
+  folderIds: string[];
+  table?: Table<FolderItemRecord, string>;
+}
+
+export async function removeFoldersFromItems({ folderIds, table }: RemoveFoldersOptions) {
+  if (!folderIds.length) {
+    return;
+  }
+
+  const folderItems = resolveTable(table);
+  await folderItems.where('folderId').anyOf(folderIds).delete();
+}

--- a/src/core/storage/gpts.ts
+++ b/src/core/storage/gpts.ts
@@ -1,4 +1,5 @@
 import { db } from './db';
+import { removeItemsFromFolders, setItemFolder } from './folderItems';
 import type { GPTRecord } from '@/core/models';
 
 function nowIso() {
@@ -34,40 +35,66 @@ export async function createGpt(input: CreateGptInput) {
     updatedAt: timestamp
   };
 
-  await db.gpts.put(record);
+  await db.transaction('rw', db.gpts, db.folderItems, async () => {
+    await db.gpts.put(record);
+    await setItemFolder({
+      itemId: record.id,
+      itemType: 'gpt',
+      folderId: record.folderId,
+      timestamp,
+      table: db.folderItems
+    });
+  });
+
   return record;
 }
 
 export async function updateGpt(input: UpdateGptInput) {
-  const changes: Partial<GPTRecord> = {
-    updatedAt: nowIso()
-  };
-
-  if (input.name !== undefined) {
-    const trimmed = input.name.trim();
-    if (!trimmed) {
-      throw new Error('GPT name is required');
+  await db.transaction('rw', db.gpts, db.folderItems, async () => {
+    const existing = await db.gpts.get(input.id);
+    if (!existing) {
+      throw new Error(`GPT ${input.id} not found`);
     }
-    changes.name = trimmed;
-  }
 
-  if (input.description !== undefined) {
-    const trimmed = input.description?.trim();
-    changes.description = trimmed ? trimmed : undefined;
-  }
+    const next: GPTRecord = {
+      ...existing,
+      updatedAt: nowIso()
+    };
 
-  if (input.folderId !== undefined) {
-    const trimmed = input.folderId?.trim();
-    changes.folderId = trimmed ? trimmed : undefined;
-  }
+    if (input.name !== undefined) {
+      const trimmed = input.name.trim();
+      if (!trimmed) {
+        throw new Error('GPT name is required');
+      }
+      next.name = trimmed;
+    }
 
-  await db.gpts.update(input.id, changes);
+    if (input.description !== undefined) {
+      const trimmed = input.description?.trim();
+      next.description = trimmed ? trimmed : undefined;
+    }
+
+    if (input.folderId !== undefined) {
+      const trimmed = input.folderId?.trim();
+      next.folderId = trimmed ? trimmed : undefined;
+    }
+
+    await db.gpts.put(next);
+    await setItemFolder({
+      itemId: next.id,
+      itemType: 'gpt',
+      folderId: next.folderId,
+      timestamp: next.updatedAt,
+      table: db.folderItems
+    });
+  });
 }
 
 export async function deleteGpt(id: string) {
-  await db.transaction('rw', db.gpts, db.prompts, async () => {
+  await db.transaction('rw', db.gpts, db.prompts, db.folderItems, async () => {
     await db.gpts.delete(id);
     await db.prompts.where('gptId').equals(id).modify({ gptId: undefined, updatedAt: nowIso() });
+    await removeItemsFromFolders({ itemType: 'gpt', itemIds: [id], table: db.folderItems });
   });
 }
 

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -1,6 +1,7 @@
 export * from './db';
 export * from './conversations';
 export * from './folders';
+export * from './folderItems';
 export * from './gpts';
 export * from './prompts';
 export * from './promptChains';


### PR DESCRIPTION
## Summary
- add a `folder_items` pivot table to the Dexie schema with a migration that seeds existing conversations, prompts, and GPTs
- centralize folder membership updates through new storage helpers and update conversation, prompt, GPT, and folder workflows plus tests to use them
- refresh the ADR, roadmap, regression checklist, and retrofit tracker to document the schema change and QA steps

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c843c1188333aae61819af2f9735