### PR TITLE
feat: add chain DSL parser prototype

### DIFF
--- a/docs/design/prompt-launcher-ux.md
+++ b/docs/design/prompt-launcher-ux.md
@@ -1,12 +1,12 @@
 # Prompt launcher — keyboard-first UX spec
 
-_Last updated: 2025-02-18_
+_Last updated: 2025-10-05_
 
 ## Context
 The launcher currently exposes saved prompts and prompt chains inside the composer. The retrofit roadmap promotes it to the
 primary entry point for reusable workflows, which means the interaction model must be extremely quick, reliable, and
-accessible. This document captures the keyboard-first experience, fuzzy search behaviours, and instrumentation required before
-we wire the flows into the shared composer store.
+accessible. This document captures the keyboard-first experience, fuzzy search behaviours, the new chain DSL tokeniser located
+in `src/core/chains/chainDslParser.ts`, and instrumentation required before we wire the flows into the shared composer store.
 
 ## Goals
 - Reduce time-to-insert for prompts/chains to <50 ms after invocation.
@@ -17,7 +17,9 @@ we wire the flows into the shared composer store.
 ## Non-goals
 - Implementing the Dexie persistence layer (already covered by existing prompt/chains storage).
 - Surfacing marketplace/community prompts (handled in a later plus roadmap phase).
-- Shipping the chain DSL interpreter (separate spike; launcher only references the registered chains).
+- Shipping the chain DSL interpreter (separate spike; launcher only references the registered chains). The initial parser now
+  normalises placeholders (`{{variable}}`) and step-output tokens (`[[step.output]]`), enabling the confirmation modal to
+  request the right inputs while renderer logic remains stubbed.
 
 ## Personas & user stories
 1. **Power user** drafting dozens of messages per hour. They expect `Ctrl+Space` (or `⌘+K` on macOS) to open a launcher, type

--- a/docs/handbook/manual-regression-checklist.md
+++ b/docs/handbook/manual-regression-checklist.md
@@ -1,6 +1,6 @@
 # Manual regression checklist
 
-_Last reviewed: 2025-02-18_
+_Last reviewed: 2025-10-05_
 
 Use this guide for every release candidate that touches the popup, dashboard/options experience, content sidebar, or storage logic. Log each run (browser, domain, commit) in the retrofit log at [`docs/handbook/retrofit-tracker.md`](./retrofit-tracker.md) so we preserve traceability.
 
@@ -113,8 +113,9 @@ Perform on `chrome-extension://<id>/options.html` with the direction toggle in b
 3. Navigate the results list using only the keyboard (`ArrowUp/Down`, `Ctrl+/` scope cycling) and insert a prompt with `Enter`; confirm highlighted tokens reflect the fuzzy search match.
 4. Type `//` in the composer to trigger the inline launcher. Confirm it anchors near the caret, honours the same keyboard controls, and restores focus to the composer after closing with `Esc`.
 5. Select a prompt chain, supply variable values in the confirmation modal, start the run, then cancel with `Esc` to ensure rollback messaging appears.
-6. Toggle the favourites filter (`Ctrl+F`) and confirm results narrow accordingly. Switch the interface to RTL and repeat the navigation once.
-7. Trigger the instruction overlay (open the launcher three times) and confirm the tip counter decrements until dismissed.
+6. Insert a prompt that references `{{variable}}` placeholders and `[[step.output]]` tokens; confirm the confirmation modal surfaces the variables, fills resolved step output text, and displays a warning when a referenced step output is missing.
+7. Toggle the favourites filter (`Ctrl+F`) and confirm results narrow accordingly. Switch the interface to RTL and repeat the navigation once.
+8. Trigger the instruction overlay (open the launcher three times) and confirm the tip counter decrements until dismissed.
 
 ## 6. Completion & logging
 1. Record outcomes, browser versions, domains tested, and any bugs in [`docs/handbook/retrofit-tracker.md`](./retrofit-tracker.md) under the logbook section.

--- a/docs/handbook/product-roadmap.md
+++ b/docs/handbook/product-roadmap.md
@@ -1,6 +1,6 @@
 # AI Browser Extension — Architecture & Delivery Roadmap
 
-_Last updated: 2025-02-18_
+_Last updated: 2025-10-05_
 
 This living document combines the architectural snapshot, delivery status, and premium launch planning for the AI Browser Extension. Update it whenever shipped functionality or priorities change so contributors have a single source of truth.
 
@@ -41,7 +41,7 @@ This living document combines the architectural snapshot, delivery status, and p
 
 ### Near-term backlog (Phase 3 focus)
 _De onderstaande punten staan ook in het retrofitlog; markeer in beide bestanden wanneer scopes verschuiven._
-- **Search & sidebar** – _Status: in uitvoering._ Dexie-schema uitgebreid met `folder_items` pivot en Minisearch verrijkt met tags/mappaden (10k benchmark gereed); zijbalk-wireframes en promptlauncher UX-spec zijn afgerond. Volgende focus: accessibility review + Zustand-state implementatie voor pin/hide flows en koppeling van de chain-parser aan de launcher.
+- **Search & sidebar** – _Status: in uitvoering._ Dexie-schema uitgebreid met `folder_items` pivot en Minisearch verrijkt met tags/mappaden (10k benchmark gereed); zijbalk-wireframes en promptlauncher UX-spec zijn afgerond. De chain DSL-parser prototype (placeholders + `[[step.output]]`) staat klaar in `src/core/chains/chainDslParser.ts`. Volgende focus: accessibility review + Zustand-state implementatie voor pin/hide flows en het koppelen van de parser aan de launcherconfirmatie.
 - Automatische jobs dashboard vervolledigen: retry hand-offs zichtbaar maken in de UI (filterpaneel live per 2025-10-05).
 - MiniSearch-indexering naar een dedicated worker verplaatsen zodat grote datasets de content thread niet blokkeren.
 - Promptketen-runner voorzien van progress feedback en annuleringsevents naar de popup.

--- a/docs/handbook/retrofit-tracker.md
+++ b/docs/handbook/retrofit-tracker.md
@@ -1,6 +1,6 @@
 # Retrofit tracker
 
-_Last reviewed: 2025-02-17_
+_Last reviewed: 2025-10-05_
 
 Dit dossier koppelt de bestaande extensie aan de nieuwe **privacy-first, local-first** roadmap. Gebruik het om pariteit met ChatGPT Toolbox te meten, plus-features te plannen en QA/retrofit-besluiten te loggen. Synchroniseer wijzigingen steeds met [`docs/handbook/product-roadmap.md`](./product-roadmap.md), de regressiegids en relevante ADR's.
 
@@ -45,7 +45,7 @@ De extensie evolueert naar een **volledige productiviteitssuite** bovenop ChatGP
   - [x] UI-wireframes voor zijbalk pin/hide/collapse flows uitwerken.
 - **Launcher ervaring**
   - [ ] Promptlauncher UX (keyboard-first) definiëren; fuzzy search testen.
-  - [ ] Chain DSL parser (placeholders, [[step.output]]) prototypen.
+  - [x] Chain DSL parser (placeholders, [[step.output]]) prototypen. _(afgerond 2025-10-05 – parsermodule + evaluatiehooks toegevoegd.)_
   - [ ] Inline triggers `//` en `..` integreren met bestaande composer store.
 - **Privacy & sync voorbereiding**
   - [ ] AES-GCM encryptieproof-of-concept in service worker met PBKDF2.
@@ -72,7 +72,11 @@ De extensie evolueert naar een **volledige productiviteitssuite** bovenop ChatGP
 4. [x] Promptlauncher UX (keyboard-first) definiëren; fuzzy search testen. _(afgerond 2025-02-18)_
    - **Prioritering** – Launcher wordt primaire toegang tot prompts/chains; keyboard-first specificatie borgt <50 ms inserties en maakt de weg vrij voor DSL-integratie. Volgende stap is chain-parserprototype koppelen aan deze UX en shortcuts configureerbaar maken via settings.
    - **Documentatie** – Nieuwe UX-notitie `docs/design/prompt-launcher-ux.md`; roadmap (`docs/handbook/product-roadmap.md`) en regressiegids (`docs/handbook/manual-regression-checklist.md`) geüpdatet met nieuwe scope en QA-stappen.
-   - **QA-notes** – Geautomatiseerd: te plannen Vitest-suite voor searchpipeline en keyboardreducer. Handmatig: heuristische toetsing uitgevoerd (keyboard-only flow, inline `//` trigger, RTL layout) en QA-checklist aangevuld met verificatiestappen voor Chrome/Firefox.
+ - **QA-notes** – Geautomatiseerd: te plannen Vitest-suite voor searchpipeline en keyboardreducer. Handmatig: heuristische toetsing uitgevoerd (keyboard-only flow, inline `//` trigger, RTL layout) en QA-checklist aangevuld met verificatiestappen voor Chrome/Firefox.
+5. [x] Chain DSL parser (placeholders, `[[step.output]]`) prototypen. _(afgerond 2025-10-05)_
+   - **Prioritering** – Parser levert nu een token-stream + evaluatiehooks zodat launcher-confirmaties variabelen en step-outputreferenties kunnen resolven. Volgende stap is integratie met de composer store en async step-runner zodat `[[step.output]]` automatisch live-data invult.
+   - **Documentatie** – Nieuwe module `src/core/chains/chainDslParser.ts`, testsuite `tests/core/chainDslParser.spec.ts`, retrofitlog (dit bestand), roadmap (`docs/handbook/product-roadmap.md`), UX-spec (`docs/design/prompt-launcher-ux.md`) en regressiegids (`docs/handbook/manual-regression-checklist.md`) bijgewerkt.
+   - **QA-notes** – Geautomatiseerd: `npm run lint`, `npm run test`, `npm run build` (Node 20.19.0). Handmatig: scenario voor placeholder/step-output validatie beschreven in regressiegids; uitvoering volgt zodra launcher-confirmatie de parser consumeert.
 
 ## Definition of done per groep
 ### Gespreksbeheer & mappen
@@ -130,5 +134,6 @@ Gebruik onderstaande scenario's als regressie-anker zodra features landen.
 | 2025-02-16 | _pending_ | Search | MiniSearch verrijkt met tags en mappaden; nieuwe tests + 10k benchmark (build 1.495 s, query 3.067 ms) gedraaid naast lint/test. |
 | 2025-02-17 | _pending_ | UX | Zijbalk pin/hide/collapse wireframes vastgelegd; QA-aanwijzingen toegevoegd en designnotitie gepubliceerd. |
 | 2025-02-18 | _pending_ | UX | Promptlauncher keyboard-first UX en fuzzy search gedrag gespecificeerd; roadmap + regressiegids gesynchroniseerd; heuristische toetsen uitgevoerd. |
+| 2025-10-05 | _pending_ | Core | Chain DSL-parser + renderer prototype toegevoegd (`src/core/chains/chainDslParser.ts`), nieuwe tests gedraaid en lint/test/build uitgevoerd; QA-checklist aangevuld met placeholder/step-output scenario. |
 
 Voeg nieuwe regels toe met `YYYY-MM-DD | commit | scope | details` en noteer welke QA (lint/test/build/manual) is uitgevoerd.

--- a/src/core/chains/chainDslParser.ts
+++ b/src/core/chains/chainDslParser.ts
@@ -1,0 +1,264 @@
+export interface ChainTemplateTokenText {
+  type: 'text';
+  value: string;
+}
+
+export interface ChainTemplateTokenVariable {
+  type: 'variable';
+  name: string;
+}
+
+export interface ChainTemplateTokenStepOutput {
+  type: 'stepOutput';
+  stepId: string;
+  property: string;
+}
+
+export type ChainTemplateToken =
+  | ChainTemplateTokenText
+  | ChainTemplateTokenVariable
+  | ChainTemplateTokenStepOutput;
+
+export interface StepOutputReference {
+  stepId: string;
+  property: string;
+}
+
+export interface ChainTemplateParseError {
+  message: string;
+  start: number;
+  end: number;
+  snippet: string;
+}
+
+export interface ChainTemplateParseResult {
+  tokens: ChainTemplateToken[];
+  variables: string[];
+  stepOutputs: StepOutputReference[];
+  errors: ChainTemplateParseError[];
+  hasErrors: boolean;
+}
+
+const variablePattern = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const identifierPattern = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+function createError(
+  message: string,
+  start: number,
+  end: number,
+  input: string
+): ChainTemplateParseError {
+  return {
+    message,
+    start,
+    end,
+    snippet: input.slice(start, Math.min(end, input.length))
+  };
+}
+
+export function parseChainTemplate(template: string): ChainTemplateParseResult {
+  const tokens: ChainTemplateToken[] = [];
+  const variables = new Map<string, number>();
+  const stepOutputs = new Map<string, StepOutputReference>();
+  const errors: ChainTemplateParseError[] = [];
+
+  let buffer = '';
+
+  function flushBuffer() {
+    if (buffer) {
+      tokens.push({ type: 'text', value: buffer });
+      buffer = '';
+    }
+  }
+
+  let index = 0;
+
+  while (index < template.length) {
+    if (template.startsWith('{{', index)) {
+      const start = index;
+      const end = template.indexOf('}}', index + 2);
+
+      if (end === -1) {
+        errors.push(
+          createError('Unclosed variable placeholder', start, template.length, template)
+        );
+        buffer += template.slice(start);
+        break;
+      }
+
+      const raw = template.slice(index + 2, end).trim();
+
+      if (!raw) {
+        errors.push(createError('Empty variable placeholder', start, end + 2, template));
+        buffer += template.slice(start, end + 2);
+        index = end + 2;
+        continue;
+      }
+
+      if (!variablePattern.test(raw)) {
+        errors.push(
+          createError(
+            'Invalid variable name; expected letters, numbers, underscores or hyphens',
+            start,
+            end + 2,
+            template
+          )
+        );
+        buffer += template.slice(start, end + 2);
+        index = end + 2;
+        continue;
+      }
+
+      flushBuffer();
+      tokens.push({ type: 'variable', name: raw });
+      if (!variables.has(raw)) {
+        variables.set(raw, tokens.length - 1);
+      }
+
+      index = end + 2;
+      continue;
+    }
+
+    if (template.startsWith('[[', index)) {
+      const start = index;
+      const end = template.indexOf(']]', index + 2);
+
+      if (end === -1) {
+        errors.push(
+          createError('Unclosed step output reference', start, template.length, template)
+        );
+        buffer += template.slice(start);
+        break;
+      }
+
+      const raw = template.slice(index + 2, end).trim();
+      const [stepPart, propertyPart, ...rest] = raw.split('.');
+
+      if (!raw || rest.length > 0) {
+        errors.push(
+          createError('Invalid step output reference syntax', start, end + 2, template)
+        );
+        buffer += template.slice(start, end + 2);
+        index = end + 2;
+        continue;
+      }
+
+      if (!stepPart || !propertyPart) {
+        errors.push(
+          createError('Step output reference must include step and property', start, end + 2, template)
+        );
+        buffer += template.slice(start, end + 2);
+        index = end + 2;
+        continue;
+      }
+
+      const stepId = stepPart.trim();
+      const property = propertyPart.trim();
+
+      if (!identifierPattern.test(stepId)) {
+        errors.push(
+          createError('Invalid step identifier', start, end + 2, template)
+        );
+        buffer += template.slice(start, end + 2);
+        index = end + 2;
+        continue;
+      }
+
+      if (!identifierPattern.test(property)) {
+        errors.push(createError('Invalid step property', start, end + 2, template));
+        buffer += template.slice(start, end + 2);
+        index = end + 2;
+        continue;
+      }
+
+      flushBuffer();
+      tokens.push({ type: 'stepOutput', stepId, property });
+
+      const key = `${stepId}.${property}`;
+      if (!stepOutputs.has(key)) {
+        stepOutputs.set(key, { stepId, property });
+      }
+
+      index = end + 2;
+      continue;
+    }
+
+    buffer += template[index];
+    index += 1;
+  }
+
+  flushBuffer();
+
+  return {
+    tokens,
+    variables: [...variables.keys()],
+    stepOutputs: [...stepOutputs.values()],
+    errors,
+    hasErrors: errors.length > 0
+  };
+}
+
+export interface RenderChainTemplateOptions {
+  variables?: Record<string, string>;
+  stepOutputs?: Record<string, Record<string, string>>;
+  onMissingVariable?: (name: string) => string | undefined;
+  onMissingStepOutput?: (reference: StepOutputReference) => string | undefined;
+}
+
+export function renderChainTemplate(
+  template: string | ChainTemplateParseResult,
+  options: RenderChainTemplateOptions = {}
+): string {
+  const parsed = typeof template === 'string' ? parseChainTemplate(template) : template;
+
+  if (parsed.hasErrors) {
+    throw new Error('Cannot render chain template with parse errors');
+  }
+
+  const parts: string[] = [];
+  const variableValues = options.variables ?? {};
+  const stepOutputValues = options.stepOutputs ?? {};
+
+  for (const token of parsed.tokens) {
+    if (token.type === 'text') {
+      parts.push(token.value);
+      continue;
+    }
+
+    if (token.type === 'variable') {
+      const resolved = variableValues[token.name];
+      if (resolved !== undefined) {
+        parts.push(resolved);
+        continue;
+      }
+
+      const fallback = options.onMissingVariable?.(token.name);
+      if (fallback !== undefined) {
+        parts.push(fallback);
+        continue;
+      }
+
+      throw new Error(`Missing value for variable "${token.name}"`);
+    }
+
+    const step = stepOutputValues[token.stepId];
+    const resolved = step?.[token.property];
+
+    if (resolved !== undefined) {
+      parts.push(resolved);
+      continue;
+    }
+
+    const fallback = options.onMissingStepOutput?.({ stepId: token.stepId, property: token.property });
+    if (fallback !== undefined) {
+      parts.push(fallback);
+      continue;
+    }
+
+    throw new Error(
+      `Missing output for step "${token.stepId}" property "${token.property}"`
+    );
+  }
+
+  return parts.join('');
+}

--- a/tests/core/chainDslParser.spec.ts
+++ b/tests/core/chainDslParser.spec.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+
+import {
+  parseChainTemplate,
+  renderChainTemplate
+} from '../../src/core/chains/chainDslParser';
+
+type AsyncTest = [name: string, execute: () => Promise<void>];
+
+const tests: AsyncTest[] = [
+  [
+    'parses variables and step outputs from chain template',
+    async () => {
+      const template = `Research on {{topic}} using [[gather.output]]. Next: [[summarise.notes]]`;
+
+      const parsed = parseChainTemplate(template);
+
+      assert.equal(parsed.hasErrors, false);
+      assert.deepEqual(parsed.variables, ['topic']);
+      assert.deepEqual(parsed.stepOutputs, [
+        { stepId: 'gather', property: 'output' },
+        { stepId: 'summarise', property: 'notes' }
+      ]);
+      assert.equal(parsed.tokens.length, 6);
+    }
+  ],
+  [
+    'reports syntax issues but preserves original text segments',
+    async () => {
+      const template = `Hello {{}} [[invalid]] [[ok.output]] {{user-name}}`;
+
+      const parsed = parseChainTemplate(template);
+
+      assert.equal(parsed.hasErrors, true);
+      assert.equal(parsed.errors.length >= 2, true);
+      const firstText = parsed.tokens.find((token) => token.type === 'text');
+      assert.equal(firstText?.type, 'text');
+      assert.ok(firstText && 'value' in firstText && firstText.value.includes('Hello'));
+      assert.deepEqual(parsed.variables, ['user-name']);
+      assert.deepEqual(parsed.stepOutputs, [{ stepId: 'ok', property: 'output' }]);
+    }
+  ],
+  [
+    'renders template with provided context and falls back via hooks',
+    async () => {
+      const template = '[[first.output]] → {{audience}} → [[second.summary]]';
+      const parsed = parseChainTemplate(template);
+
+      const rendered = renderChainTemplate(parsed, {
+        variables: { audience: 'Designers' },
+        stepOutputs: {
+          first: { output: 'Research doc' }
+        },
+        onMissingStepOutput: ({ stepId }) => (stepId === 'second' ? 'Pending' : undefined)
+      });
+
+      assert.equal(rendered, 'Research doc → Designers → Pending');
+    }
+  ]
+];
+
+async function run() {
+  let hasFailure = false;
+
+  for (const [name, execute] of tests) {
+    try {
+      await execute();
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      hasFailure = true;
+      console.error(`✖ ${name}`);
+      console.error(error);
+    }
+  }
+
+  if (hasFailure) {
+    process.exitCode = 1;
+  }
+}
+
+await run();

--- a/tests/runAll.ts
+++ b/tests/runAll.ts
@@ -5,6 +5,7 @@ async function runSequentially() {
   await import('./conversationIngestion.spec');
   await import('./jobScheduler.spec');
   await import('./core/searchService.spec');
+  await import('./core/chainDslParser.spec');
   await import('./backgroundMessaging.spec');
   await import('./shared/bubbleLauncherStore.spec');
 }


### PR DESCRIPTION
## Summary
- add a chain DSL parser module that normalises placeholders and step output references
- cover the parser with a dedicated spec and include it in the runAll harness
- document the parser delivery in the retrofit tracker, roadmap, UX spec, and regression checklist

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2d0c6d17883339f8f73024b5f2d51