### PR TITLE
feat: add sync encryption poc for service worker

### DIFF
--- a/docs/handbook/manual-regression-checklist.md
+++ b/docs/handbook/manual-regression-checklist.md
@@ -1,6 +1,6 @@
 # Manual regression checklist
 
-_Last reviewed: 2025-10-05_
+_Last reviewed: 2025-10-08_
 
 Use this guide for every release candidate that touches the popup, dashboard/options experience, content sidebar, or storage logic. Log each run (browser, domain, commit) in the retrofit log at [`docs/handbook/retrofit-tracker.md`](./retrofit-tracker.md) so we preserve traceability.
 
@@ -117,7 +117,15 @@ Perform on `chrome-extension://<id>/options.html` with the direction toggle in b
 7. Toggle the favourites filter (`Ctrl+F`) and confirm results narrow accordingly. Switch the interface to RTL and repeat the navigation once.
 8. Trigger the instruction overlay (open the launcher three times) and confirm the tip counter decrements until dismissed.
 
-## 6. Completion & logging
+## 6. Privacy & sync encryptieproof-of-concept
+1. Open `chrome://extensions` → background service worker console en voer `chrome.runtime.sendMessage({ type: 'sync/encryption-configure', payload: { passphrase: 'Manual QA secret 01' } })` uit. Verwacht `{ status: 'configured' }` en een bevestigde status via `chrome.runtime.sendMessage({ type: 'sync/encryption-status', payload: {} })` met `configured: true` en `unlocked: true`.
+2. Vraag een encryptie aan met `chrome.runtime.sendMessage({ type: 'sync/encryption-encrypt', payload: { plaintext: 'QA roundtrip' } })`. Noteer het ontvangen `envelope` object en valideer dat `status: 'ok'` is.
+3. Voer `chrome.runtime.sendMessage({ type: 'sync/encryption-lock', payload: {} })` uit en bevestig via `sync/encryption-status` dat `unlocked: false`.
+4. Probeer het opgeslagen `envelope` te decrypten terwijl het slot actief is (`sync/encryption-decrypt`). Verwacht een `{ status: 'locked' }` antwoord.
+5. Ontgrendel met dezelfde passphrase (`sync/encryption-unlock`) en herhaal de decryptie. Het resultaat moet `{ status: 'ok', plaintext: 'QA roundtrip' }` opleveren.
+6. Test een foutscenario door `sync/encryption-unlock` met een fout wachtwoord aan te roepen; verwacht `{ status: 'invalid' }`. Sluit af met `sync/encryption-lock` en log de console-uitvoer in het retrofitlog.
+
+## 7. Completion & logging
 1. Record outcomes, browser versions, domains tested, and any bugs in [`docs/handbook/retrofit-tracker.md`](./retrofit-tracker.md) under the logbook section.
 2. Attach relevant console logs or screenshots to the shared QA archive, referencing them from the log entry.
 

--- a/docs/handbook/product-roadmap.md
+++ b/docs/handbook/product-roadmap.md
@@ -1,6 +1,6 @@
 # AI Browser Extension — Architecture & Delivery Roadmap
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-10-08_
 
 This living document combines the architectural snapshot, delivery status, and premium launch planning for the AI Browser Extension. Update it whenever shipped functionality or priorities change so contributors have a single source of truth.
 
@@ -24,6 +24,7 @@ This living document combines the architectural snapshot, delivery status, and p
 - **Zoekservice** – MiniSearch-index wordt naar IndexedDB weggeschreven en bij opstart hersteld; documenten bevatten nu titels, tag-tokens en volledige mappaden. Verwijderingen houden conversatie- en berichtdocumenten in sync en een 10k-berichtencoldbuild klokt ~1,5 s met zoeklatency rond 3 ms.
 - **Export pipeline** – TXT/JSON exports gebruiken client-side helpers; de background handler maakt bestanden aan en start automatisch een `chrome.downloads.download` zodra de job slaagt.
 - **Authenticatie** – `AuthManager` decodeert JWT’s lokaal, deriveert premiumstatus en ondersteunt optionele JWKS caching. Signatuurvalidatie en refreshflows zijn nog niet geïmplementeerd.
+- **Sync encryptie POC** – Background service worker deriveert AES-GCM sleutels via PBKDF2, bewaart verificatieciphertexts en stelt messagingroutes beschikbaar voor encrypt/decrypt rondtrips. UI en Dexie-integratie volgen in de volgende iteratie.
 
 ## Delivery phases
 
@@ -34,7 +35,7 @@ This living document combines the architectural snapshot, delivery status, and p
 | 2 | Workspace management | ✅ Delivered | Popup cards, dashboard filters, folders, prompt/GPT CRUD, i18n/RTL. |
 | 3 | Productivity automation | 🚧 In progress | Job queue + export handlers live; search durability en extra UI polish volgen. |
 | 4 | Audio tooling | 💤 Planned | Geen echte audio-opname of playback pipelines; media-instellingen zijn placeholders. |
-| 5 | Sync & collaboration | 💤 Planned | Encryptie, cross-device merge en gedeelde workspaces ontbreken. |
+| 5 | Sync & collaboration | 🚧 In progress | AES-GCM/PBKDF2 proof-of-concept actief in service worker; volgende stap is Dexie snapshot encryptie en passphrasebeheer UI. |
 | 6 | Intelligence & insights | 💤 Planned | Geen automatische analyses of aanbevelingen buiten huidige datacaptatie. |
 | 7 | Platform extensibility | 💤 Planned | Side-panel integraties en externe API hooks nog niet gespecificeerd. |
 | 8 | Quality & growth | 💤 Planned | Telemetry storage, observability en lokalisatie scorecards moeten nog worden opgezet. |
@@ -46,6 +47,7 @@ _De onderstaande punten staan ook in het retrofitlog; markeer in beide bestanden
 - MiniSearch-indexering naar een dedicated worker verplaatsen zodat grote datasets de content thread niet blokkeren.
 - Promptketen-runner voorzien van progress feedback en annuleringsevents naar de popup.
 - Contextmenu focusbeheer verbeteren (focus trap + refocus van het origineel) en documenteren in de accessibility playbook.
+- **Privacy & sync** – _Status: POC gereed._ AES-GCM/PBKDF2 encryptieservice draait in de background worker. Volgende iteratie koppelt Dexie sync-snapshots aan de service en levert passphrasebeheer in opties + onboarding.
 
 ### Toekomstige thema’s (Phases 4–8)
 Documenteer outstanding design/ADR links voordat ontwikkeling start. Maak nieuwe ADR’s alleen aan wanneer implementatie committers klaarstaan, zodat contributors scope kunnen traceren zonder te gissen.

--- a/docs/handbook/retrofit-tracker.md
+++ b/docs/handbook/retrofit-tracker.md
@@ -1,6 +1,6 @@
 # Retrofit tracker
 
-_Last reviewed: 2025-10-05_
+_Last reviewed: 2025-10-08_
 
 Dit dossier koppelt de bestaande extensie aan de nieuwe **privacy-first, local-first** roadmap. Gebruik het om pariteit met ChatGPT Toolbox te meten, plus-features te plannen en QA/retrofit-besluiten te loggen. Synchroniseer wijzigingen steeds met [`docs/handbook/product-roadmap.md`](./product-roadmap.md), de regressiegids en relevante ADR's.
 
@@ -85,6 +85,10 @@ De extensie evolueert naar een **volledige productiviteitssuite** bovenop ChatGP
    - **Prioritering** – Confirmatiemodal leest nu prompttemplates via de DSL-parser, toont variabelen met live-preview en levert een `ChainRunPlan` aan de content-runner. Daarmee worden inline `//`/`..` flows fouttolerant en staat het fundament voor de asynchrone step-runner (cancel/resume & step-output streaming).
    - **Documentatie** – Roadmap (`docs/handbook/product-roadmap.md`) bijgewerkt met de nieuwe run-plan architectuur; regressiegids (`docs/handbook/manual-regression-checklist.md`) uitgebreid met de modal-verificatie; retrofitlog en logboek aangevuld. Nieuwe types gedocumenteerd in `src/shared/types/promptChains.ts`.
    - **QA-notes** – Geautomatiseerd: `npm run lint`, `npm run test`, `npm run build` (Node 20.19.0). Handmatig: via `//` en `..` een chain met `{{variable}}` en `[[step.output]]` starten, controleren dat de modal waarden verplicht stelt, placeholders realtime rendert en na annuleren opnieuw lege invoer biedt; resultaten vastleggen in regressiegids.
+8. [x] AES-GCM encryptieproof-of-concept in service worker met PBKDF2. _(afgerond 2025-10-08)_
+   - **Prioritering** – Sync-roadmap vereist een verifieerbare sleutelafleiding voordat opt-in promptsync kan landen. Dit POC levert een backgroundservice die passphrases via PBKDF2 → AES-GCM sleutels deriveert, verificatieciphertext bewaakt en encrypt/decrypt messaging routes aanbiedt. Volgende stap is het verbinden met Dexie sync-snapshots en UI voor passphrasebeheer.
+   - **Documentatie** – Nieuwe module `src/background/crypto/syncEncryption.ts`, type `src/shared/types/syncEncryption.ts`, messaging-contract (`src/shared/messaging/contracts.ts`) en tests `tests/background/syncEncryptionService.spec.ts` toegevoegd. Retrofitlog (dit bestand), roadmap (`docs/handbook/product-roadmap.md`) en regressiegids (`docs/handbook/manual-regression-checklist.md`) zijn bijgewerkt met de encryptiestroom en QA-instructies.
+   - **QA-notes** – Geautomatiseerd: `npm run lint`, `npm run test`, `npm run build` (Node 20.19.0). Handmatig: in service-worker console `chrome.runtime.sendMessage({ type: 'sync/encryption-configure', payload: { passphrase: 'demo passphrase' } })` uitvoeren, status controleren via `sync/encryption-status`, daarna encrypt/decrypt rondtrip testen en `sync/encryption-lock` + `sync/encryption-unlock` doorlopen; resultaten documenteren in regressiegids.
 
 ## Definition of done per groep
 ### Gespreksbeheer & mappen
@@ -145,5 +149,6 @@ Gebruik onderstaande scenario's als regressie-anker zodra features landen.
 | 2025-10-05 | _pending_ | Core | Chain DSL-parser + renderer prototype toegevoegd (`src/core/chains/chainDslParser.ts`), nieuwe tests gedraaid en lint/test/build uitgevoerd; QA-checklist aangevuld met placeholder/step-output scenario. |
 | 2025-10-06 | _pending_ | Content | Inline launcher triggers koppelen aan composer store (`textareaPrompts.ts` + helpermodule), promptfilter auto-gevuld, tests toegevoegd en lint/test/build gedraaid; manual checklist uitgebreid met `//`/`..` scenario. |
 | 2025-10-07 | _pending_ | Content | Chain-confirmatiemodal toegevoegd met parserbinding en run-plan export (`textareaPrompts.ts`, `shared/types/promptChains.ts`, `chainRunner.ts`); roadmap en regressiegids geüpdatet; lint/test/build uitgevoerd en handmatig modal-flow geverifieerd. |
+| 2025-10-08 | _pending_ | Background | AES-GCM encryptie POC toegevoegd (`src/background/crypto/syncEncryption.ts`) met messaging-routes en tests (`tests/background/syncEncryptionService.spec.ts`); lint/test/build gedraaid en handmatige consoleflow beschreven in regressiegids. |
 
 Voeg nieuwe regels toe met `YYYY-MM-DD | commit | scope | details` en noteer welke QA (lint/test/build/manual) is uitgevoerd.

--- a/src/background/crypto/syncEncryption.ts
+++ b/src/background/crypto/syncEncryption.ts
@@ -1,0 +1,345 @@
+import { SyncEncryptionEnvelope, type SyncEncryptionStatus } from '@/shared/types/syncEncryption';
+
+const METADATA_STORAGE_KEY = 'ai-companion:sync-encryption:metadata';
+const ENVELOPE_VERSION = 1;
+const DEFAULT_ITERATIONS = 310_000;
+const VERIFICATION_PLAINTEXT = 'ai-companion:sync-verification:v1';
+
+export class SyncEncryptionLockedError extends Error {
+  constructor() {
+    super('Sync encryption key is locked.');
+    this.name = 'SyncEncryptionLockedError';
+  }
+}
+
+export class SyncEncryptionNotConfiguredError extends Error {
+  constructor() {
+    super('Sync encryption is not configured.');
+    this.name = 'SyncEncryptionNotConfiguredError';
+  }
+}
+
+export class SyncEncryptionInvalidPassphraseError extends Error {
+  constructor() {
+    super('The provided passphrase is invalid.');
+    this.name = 'SyncEncryptionInvalidPassphraseError';
+  }
+}
+
+interface SyncEncryptionMetadata {
+  version: number;
+  salt: string;
+  iterations: number;
+  verification: SyncEncryptionEnvelope;
+}
+
+interface StorageOptions {
+  fallbackStore?: Map<string, unknown>;
+}
+
+function getLocalStorageArea(): chrome.storage.StorageArea | undefined {
+  if (typeof chrome === 'undefined' || !chrome.storage?.local) {
+    return undefined;
+  }
+  return chrome.storage.local;
+}
+
+async function storageGet(key: string, fallback: Map<string, unknown>): Promise<Record<string, unknown> | undefined> {
+  const storage = getLocalStorageArea();
+  if (!storage) {
+    if (!fallback.has(key)) {
+      return undefined;
+    }
+    return { [key]: fallback.get(key) };
+  }
+
+  if ('get' in storage && storage.get.length === 1) {
+    return (storage.get as (keys: string) => Promise<Record<string, unknown>>)(key);
+  }
+
+  return new Promise<Record<string, unknown> | undefined>((resolve, reject) => {
+    try {
+      storage.get(key, (result) => {
+        const error = chrome.runtime?.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(result);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function storageSet(key: string, value: unknown, fallback: Map<string, unknown>): Promise<void> {
+  const storage = getLocalStorageArea();
+  if (!storage) {
+    fallback.set(key, value);
+    return;
+  }
+
+  if ('set' in storage && storage.set.length === 1) {
+    await (storage.set as (items: Record<string, unknown>) => Promise<void>)({ [key]: value });
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      storage.set({ [key]: value }, () => {
+        const error = chrome.runtime?.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function storageRemove(key: string, fallback: Map<string, unknown>): Promise<void> {
+  const storage = getLocalStorageArea();
+  if (!storage) {
+    fallback.delete(key);
+    return;
+  }
+
+  if ('remove' in storage && storage.remove.length === 1) {
+    await (storage.remove as (keys: string) => Promise<void>)(key);
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      storage.remove(key, () => {
+        const error = chrome.runtime?.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buffer).toString('base64');
+  }
+
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]!);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(value: string): ArrayBuffer {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(value, 'base64')).buffer;
+  }
+
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+function getCrypto(): Crypto {
+  if (!globalThis.crypto || !globalThis.crypto.subtle) {
+    throw new Error('WebCrypto is not available in this environment.');
+  }
+  return globalThis.crypto;
+}
+
+export interface SyncEncryptionServiceOptions extends StorageOptions {
+  iterations?: number;
+}
+
+export interface SyncEncryptionConfigureOptions {
+  passphrase: string;
+}
+
+export interface SyncEncryptionUnlockOptions {
+  passphrase: string;
+}
+
+export interface SyncEncryptionEncryptOptions {
+  plaintext: string;
+}
+
+export class SyncEncryptionService {
+  private readonly fallback: Map<string, unknown>;
+  private readonly iterations: number;
+  private key: CryptoKey | null = null;
+  private metadataPromise: Promise<SyncEncryptionMetadata | null> | null = null;
+
+  constructor(options: SyncEncryptionServiceOptions = {}) {
+    this.fallback = options.fallbackStore ?? new Map();
+    this.iterations = options.iterations ?? DEFAULT_ITERATIONS;
+  }
+
+  async getStatus(): Promise<SyncEncryptionStatus> {
+    const metadata = await this.loadMetadata();
+    return {
+      configured: Boolean(metadata),
+      unlocked: this.key !== null,
+      iterations: metadata?.iterations ?? null
+    };
+  }
+
+  async configure(options: SyncEncryptionConfigureOptions): Promise<void> {
+    const crypto = getCrypto();
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await this.deriveKey(options.passphrase, salt, this.iterations);
+    const verification = await this.createVerification(key);
+
+    const metadata: SyncEncryptionMetadata = {
+      version: ENVELOPE_VERSION,
+      salt: arrayBufferToBase64(salt.buffer),
+      iterations: this.iterations,
+      verification
+    };
+
+    await storageSet(METADATA_STORAGE_KEY, metadata, this.fallback);
+    this.metadataPromise = Promise.resolve(metadata);
+    this.key = key;
+  }
+
+  async unlock(options: SyncEncryptionUnlockOptions): Promise<void> {
+    const metadata = await this.loadMetadata();
+    if (!metadata) {
+      throw new SyncEncryptionNotConfiguredError();
+    }
+
+    const salt = new Uint8Array(base64ToArrayBuffer(metadata.salt));
+    const key = await this.deriveKey(options.passphrase, salt, metadata.iterations);
+    await this.verifyKey(key, metadata.verification);
+    this.key = key;
+  }
+
+  lock(): void {
+    this.key = null;
+  }
+
+  async clear(): Promise<void> {
+    this.key = null;
+    this.metadataPromise = null;
+    await storageRemove(METADATA_STORAGE_KEY, this.fallback);
+  }
+
+  async encryptString(options: SyncEncryptionEncryptOptions): Promise<SyncEncryptionEnvelope> {
+    const key = await this.ensureKey();
+    const crypto = getCrypto();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoder = new TextEncoder();
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoder.encode(options.plaintext));
+
+    return {
+      version: ENVELOPE_VERSION,
+      iv: arrayBufferToBase64(iv.buffer),
+      data: arrayBufferToBase64(ciphertext)
+    };
+  }
+
+  async decryptToString(envelope: SyncEncryptionEnvelope): Promise<string> {
+    if (envelope.version !== ENVELOPE_VERSION) {
+      throw new Error(`Unsupported envelope version: ${envelope.version}`);
+    }
+
+    const key = await this.ensureKey();
+    const crypto = getCrypto();
+    const iv = new Uint8Array(base64ToArrayBuffer(envelope.iv));
+    const ciphertext = base64ToArrayBuffer(envelope.data);
+
+    try {
+      const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+      return new TextDecoder().decode(decrypted);
+    } catch (error) {
+      throw new SyncEncryptionInvalidPassphraseError();
+    }
+  }
+
+  private async ensureKey(): Promise<CryptoKey> {
+    if (this.key) {
+      return this.key;
+    }
+
+    const metadata = await this.loadMetadata();
+    if (!metadata) {
+      throw new SyncEncryptionNotConfiguredError();
+    }
+
+    throw new SyncEncryptionLockedError();
+  }
+
+  private async loadMetadata(): Promise<SyncEncryptionMetadata | null> {
+    if (!this.metadataPromise) {
+      this.metadataPromise = (async () => {
+        const result = await storageGet(METADATA_STORAGE_KEY, this.fallback);
+        const value = result?.[METADATA_STORAGE_KEY] as SyncEncryptionMetadata | undefined;
+        return value ?? null;
+      })();
+    }
+    return this.metadataPromise;
+  }
+
+  private async deriveKey(passphrase: string, salt: Uint8Array, iterations: number): Promise<CryptoKey> {
+    const crypto = getCrypto();
+    const encoder = new TextEncoder();
+    const baseKey = await crypto.subtle.importKey('raw', encoder.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+    const saltBuffer = Uint8Array.from(salt).buffer;
+    return crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt: saltBuffer, iterations, hash: 'SHA-256' },
+      baseKey,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  private async createVerification(key: CryptoKey): Promise<SyncEncryptionEnvelope> {
+    const crypto = getCrypto();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoder = new TextEncoder();
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoder.encode(VERIFICATION_PLAINTEXT));
+
+    return {
+      version: ENVELOPE_VERSION,
+      iv: arrayBufferToBase64(iv.buffer),
+      data: arrayBufferToBase64(ciphertext)
+    };
+  }
+
+  private async verifyKey(key: CryptoKey, envelope: SyncEncryptionEnvelope): Promise<void> {
+    const crypto = getCrypto();
+    const iv = new Uint8Array(base64ToArrayBuffer(envelope.iv));
+    const ciphertext = base64ToArrayBuffer(envelope.data);
+
+    try {
+      const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+      const decoded = new TextDecoder().decode(decrypted);
+      if (decoded !== VERIFICATION_PLAINTEXT) {
+        throw new SyncEncryptionInvalidPassphraseError();
+      }
+    } catch (error) {
+      throw new SyncEncryptionInvalidPassphraseError();
+    }
+  }
+}
+
+export function createSyncEncryptionService(options?: SyncEncryptionServiceOptions) {
+  return new SyncEncryptionService(options);
+}
+
+export type { SyncEncryptionEnvelope };

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,6 @@
 import { createAuthManager } from './auth';
 import { createExportJobHandler } from './jobs/exportHandler';
+import { createSyncEncryptionService } from './crypto/syncEncryption';
 import { createEventLoggerJobHandler } from './jobs/eventLogger';
 import { createJobScheduler } from './jobs/scheduler';
 import { initializeMessaging } from './messaging';
@@ -11,6 +12,7 @@ const jobScheduler = createJobScheduler({
     console.error('[ai-companion] job failed', job.id, error);
   }
 });
+const syncEncryption = createSyncEncryptionService();
 
 authManager.initialize().catch((error) => {
   console.warn('[ai-companion] failed to initialize auth manager', error);
@@ -21,7 +23,7 @@ jobScheduler.registerHandler('event', createEventLoggerJobHandler());
 
 jobScheduler.start();
 
-initializeMessaging({ auth: authManager, scheduler: jobScheduler });
+initializeMessaging({ auth: authManager, scheduler: jobScheduler, encryption: syncEncryption });
 
 function setupContextMenus() {
   chrome.contextMenus.create({

--- a/src/shared/messaging/contracts.ts
+++ b/src/shared/messaging/contracts.ts
@@ -1,5 +1,6 @@
 import type { JobSnapshot, JobStatus } from '@/core/models';
 import type { ChainRunPlan } from '@/shared/types/promptChains';
+import type { SyncEncryptionEnvelope, SyncEncryptionStatus } from '@/shared/types/syncEncryption';
 
 export interface MessageSchema {
   request: unknown;
@@ -68,6 +69,37 @@ export interface RuntimeMessageMap extends MessageMapDefinition {
   'jobs/list': {
     request: { limit?: number; statuses?: JobStatus[] };
     response: { jobs: JobSnapshot[]; fetchedAt: string };
+  };
+  'sync/encryption-status': {
+    request: Record<string, never>;
+    response: SyncEncryptionStatus;
+  };
+  'sync/encryption-configure': {
+    request: { passphrase: string };
+    response: { status: 'configured' };
+  };
+  'sync/encryption-unlock': {
+    request: { passphrase: string };
+    response: { status: 'unlocked' } | { status: 'invalid' } | { status: 'not_configured' };
+  };
+  'sync/encryption-lock': {
+    request: Record<string, never>;
+    response: { status: 'locked' };
+  };
+  'sync/encryption-encrypt': {
+    request: { plaintext: string };
+    response:
+      | { status: 'ok'; envelope: SyncEncryptionEnvelope }
+      | { status: 'locked' }
+      | { status: 'not_configured' };
+  };
+  'sync/encryption-decrypt': {
+    request: { envelope: SyncEncryptionEnvelope };
+    response:
+      | { status: 'ok'; plaintext: string }
+      | { status: 'locked' }
+      | { status: 'invalid' }
+      | { status: 'not_configured' };
   };
 }
 

--- a/src/shared/types/syncEncryption.ts
+++ b/src/shared/types/syncEncryption.ts
@@ -1,0 +1,11 @@
+export interface SyncEncryptionEnvelope {
+  version: number;
+  iv: string;
+  data: string;
+}
+
+export interface SyncEncryptionStatus {
+  configured: boolean;
+  unlocked: boolean;
+  iterations: number | null;
+}

--- a/tests/background/syncEncryptionService.spec.ts
+++ b/tests/background/syncEncryptionService.spec.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+
+import {
+  createSyncEncryptionService,
+  SyncEncryptionInvalidPassphraseError,
+  SyncEncryptionLockedError,
+  SyncEncryptionNotConfiguredError
+} from '@/background/crypto/syncEncryption';
+
+async function run() {
+  const fallback = new Map<string, unknown>();
+  const service = createSyncEncryptionService({ fallbackStore: fallback });
+
+  const initialStatus = await service.getStatus();
+  assert.deepEqual(initialStatus, { configured: false, unlocked: false, iterations: null });
+
+  await service.configure({ passphrase: 'correct horse battery staple' });
+
+  const postConfigureStatus = await service.getStatus();
+  assert.equal(postConfigureStatus.configured, true);
+  assert.equal(postConfigureStatus.unlocked, true);
+  assert.equal(typeof postConfigureStatus.iterations, 'number');
+
+  const envelope = await service.encryptString({ plaintext: 'secret payload' });
+  assert.equal(envelope.version, 1);
+  assert.notEqual(envelope.data.length, 0);
+
+  const decrypted = await service.decryptToString(envelope);
+  assert.equal(decrypted, 'secret payload');
+
+  service.lock();
+  const lockedStatus = await service.getStatus();
+  assert.equal(lockedStatus.unlocked, false);
+
+  await assert.rejects(() => service.decryptToString(envelope), SyncEncryptionLockedError);
+
+  await service.unlock({ passphrase: 'correct horse battery staple' });
+  const unlockedStatus = await service.getStatus();
+  assert.equal(unlockedStatus.unlocked, true);
+
+  const decryptedAfterUnlock = await service.decryptToString(envelope);
+  assert.equal(decryptedAfterUnlock, 'secret payload');
+
+  service.lock();
+  await assert.rejects(() => service.unlock({ passphrase: 'wrong passphrase' }), SyncEncryptionInvalidPassphraseError);
+
+  await service.clear();
+  await assert.rejects(() => service.unlock({ passphrase: 'correct horse battery staple' }), SyncEncryptionNotConfiguredError);
+
+  const clearedStatus = await service.getStatus();
+  assert.equal(clearedStatus.configured, false);
+  assert.equal(clearedStatus.unlocked, false);
+
+  const storedMetadata = fallback.get('ai-companion:sync-encryption:metadata');
+  assert.equal(storedMetadata, undefined);
+
+  console.log('✓ sync encryption service proof-of-concept passed');
+}
+
+await run();

--- a/tests/runAll.ts
+++ b/tests/runAll.ts
@@ -8,6 +8,7 @@ async function runSequentially() {
   await import('./core/searchService.spec');
   await import('./core/chainDslParser.spec');
   await import('./backgroundMessaging.spec');
+  await import('./background/syncEncryptionService.spec');
   await import('./shared/bubbleLauncherStore.spec');
 }
 


### PR DESCRIPTION
## Summary
- add a background sync encryption service that derives AES-GCM keys with PBKDF2 and expose messaging routes for configure/unlock/encrypt/decrypt flows
- cover the service with automated tests, register the new suite in the harness, and update background messaging tests to stub encryption dependencies
- document the proof-of-concept and QA flow across the retrofit tracker, roadmap, and manual regression checklist

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e34815f3d483339eb7775f9d39ef80