### PR TITLE
feat: add virtualized media gallery to options

### DIFF
--- a/docs/handbook/manual-regression-checklist.md
+++ b/docs/handbook/manual-regression-checklist.md
@@ -121,6 +121,15 @@ Perform on `chrome-extension://<id>/options.html` with the direction toggle in b
 2. Change the default voice from the dropdown and verify the preview overlay reflects the selection.
 3. Open the **Preview voice overlay**, check that focus stays trapped inside, and close it with both the confirm button and `Escape`.
 4. Launch the **Learn about modals** dialog and confirm focus returns to the trigger after closing.
+5. Scroll through the **Media gallery** card:
+   - Use the mouse wheel to move from top to bottom; new thumbnails should stream in batches of ~60 with a skeleton shimmer while loading.
+   - Flick to the end of the list and confirm the “Loading more…” banner appears briefly without layout jumps or duplicate rows.
+6. Apply each gallery filter (All media / Audio / Video / Images):
+   - Switching filters should reset the scroll position to the top and immediately swap the tile set.
+   - Change the filter while scrolled halfway and verify the grid re-renders without blank gaps or repeated items.
+7. Virtual scroll stress test:
+   - Resize the window below 900 px wide and scroll rapidly; performance should stay smooth (<300 ms render spikes) and the counter (e.g. “240 of 1000 media items”) updates as pages stream in.
+   - Reload the options page; skeleton tiles should appear for <1 s before demo media repopulates.
 
 ### 3.6 Passphrase & sync encryptie
 1. Open de sectie **Wachtwoordzin & sync-encryptie** in het dashboard. Controleer dat de statusbadge “Nog niet ingesteld” toont bij een schone installatie en dat PBKDF2-iteraties zichtbaar worden zodra een passphrase is opgeslagen.

--- a/src/core/models/records.ts
+++ b/src/core/models/records.ts
@@ -86,6 +86,26 @@ export interface BookmarkRecord {
   messagePreview?: string;
 }
 
+export type MediaItemType = 'audio' | 'video' | 'image';
+
+export type MediaItemFilter = MediaItemType | 'all';
+
+export interface MediaItemRecord {
+  id: string;
+  type: MediaItemType;
+  title: string;
+  description?: string;
+  createdAt: string;
+  sortKey: number;
+  durationSeconds: number;
+  sizeKb: number;
+  dominantColor: string;
+  accentColor: string;
+  thumbnailLabel: string;
+  collection: string;
+  tags?: string[];
+}
+
 export type ConversationPinnedFilter = 'all' | 'pinned' | 'unpinned';
 
 export type ConversationArchivedFilter = 'all' | 'archived' | 'active';

--- a/src/core/storage/db.ts
+++ b/src/core/storage/db.ts
@@ -7,6 +7,7 @@ import type {
   GPTRecord,
   JobRecord,
   MessageRecord,
+  MediaItemRecord,
   PromptChainRecord,
   PromptRecord,
   SettingsRecord
@@ -55,6 +56,7 @@ export class CompanionDatabase extends Dexie {
   settings!: Table<SettingsRecord, string>;
   jobs!: Table<JobRecord, string>;
   metadata!: Table<MetadataRecord, string>;
+  mediaItems!: Table<MediaItemRecord, string>;
 
   constructor() {
     super('AICompanionDB');
@@ -264,6 +266,21 @@ export class CompanionDatabase extends Dexie {
           await folderItemsTable.bulkAdd(records);
         }
       });
+
+    this.version(9).stores({
+      conversations: 'id, updatedAt, folderId, pinned, archived',
+      messages: 'id, [conversationId+createdAt], conversationId, createdAt',
+      gpts: 'id, folderId, updatedAt',
+      prompts: 'id, folderId, gptId, updatedAt',
+      promptChains: 'id, updatedAt',
+      folders: 'id, parentId, kind, favorite',
+      folderItems: 'id, folderId, itemType, itemId, &[itemType+itemId], [folderId+itemType], sortIndex',
+      bookmarks: 'id, [conversationId+messageId], conversationId, createdAt',
+      settings: 'id',
+      jobs: 'id, status, runAt, updatedAt',
+      metadata: 'key',
+      mediaItems: 'id, sortKey, type, [type+sortKey]'
+    });
   }
 }
 

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -9,3 +9,4 @@ export * from './settings';
 export * from './syncBridge';
 export * from './service';
 export * from './insights';
+export * from './mediaItems';

--- a/src/core/storage/mediaItems.ts
+++ b/src/core/storage/mediaItems.ts
@@ -1,0 +1,117 @@
+import type { MediaItemFilter, MediaItemRecord, MediaItemType } from '@/core/models';
+
+import { db } from './db';
+
+const DEFAULT_SEED_COUNT = 1000;
+const MEDIA_TYPES: MediaItemType[] = ['audio', 'video', 'image'];
+
+const TYPE_METADATA: Record<MediaItemType, { dominant: string; accent: string; collection: string; tags: string[]; prefix: string }> = {
+  audio: {
+    dominant: '#0f172a',
+    accent: '#22d3ee',
+    collection: 'Voice captures',
+    tags: ['voice', 'capture'],
+    prefix: 'Clip'
+  },
+  video: {
+    dominant: '#1e293b',
+    accent: '#a855f7',
+    collection: 'Recordings',
+    tags: ['session', 'walkthrough'],
+    prefix: 'Session'
+  },
+  image: {
+    dominant: '#111827',
+    accent: '#34d399',
+    collection: 'Screenshots',
+    tags: ['reference', 'snapshot'],
+    prefix: 'Still'
+  }
+};
+
+export async function countMediaItems(type: MediaItemFilter = 'all') {
+  if (type === 'all') {
+    const items = await db.mediaItems.toArray();
+    return items.length;
+  }
+
+  const items = await db.mediaItems.where('type').equals(type).toArray();
+  return items.length;
+}
+
+export async function seedMediaItems(target = DEFAULT_SEED_COUNT) {
+  const existing = await countMediaItems();
+
+  if (existing >= target) {
+    return existing;
+  }
+
+  const missing = target - existing;
+  const now = Date.now();
+  const records: MediaItemRecord[] = [];
+
+  for (let index = 0; index < missing; index += 1) {
+    const sequence = existing + index;
+    const type = MEDIA_TYPES[sequence % MEDIA_TYPES.length];
+    const metadata = TYPE_METADATA[type];
+    const sortKey = now - sequence;
+    const createdAt = new Date(sortKey).toISOString();
+    const title = `${metadata.prefix} ${String(sequence + 1).padStart(3, '0')}`;
+
+    records.push({
+      id: crypto.randomUUID(),
+      type,
+      title,
+      description: `Demo ${type} asset generated for gallery performance benchmarks.`,
+      createdAt,
+      sortKey,
+      durationSeconds: 25 + ((sequence * 7) % 95),
+      sizeKb: 320 + ((sequence * 13) % 2048),
+      dominantColor: metadata.dominant,
+      accentColor: metadata.accent,
+      thumbnailLabel: title.slice(0, 2).toUpperCase(),
+      collection: metadata.collection,
+      tags: metadata.tags
+    });
+  }
+
+  if (records.length) {
+    await db.mediaItems.bulkPut(records);
+  }
+
+  return existing + records.length;
+}
+
+export interface ListMediaItemsOptions {
+  limit?: number;
+  cursor?: number | null;
+  type?: MediaItemFilter;
+}
+
+export interface ListMediaItemsResult {
+  items: MediaItemRecord[];
+  nextCursor: number | null;
+  total: number;
+}
+
+export async function listMediaItems(options: ListMediaItemsOptions = {}): Promise<ListMediaItemsResult> {
+  const limit = Math.max(1, Math.min(options.limit ?? 60, 500));
+  const cursor = options.cursor ?? null;
+  const type = options.type ?? 'all';
+
+  const [orderedItems, total] = await Promise.all([
+    db.mediaItems.orderBy('sortKey').reverse().toArray(),
+    countMediaItems(type)
+  ]);
+
+  const filtered = orderedItems.filter((item) => (type === 'all' ? true : item.type === type));
+  const sliced = cursor !== null ? filtered.filter((item) => item.sortKey < cursor) : filtered;
+  const items = sliced.slice(0, limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].sortKey : null;
+
+  return {
+    items,
+    nextCursor,
+    total
+  };
+}

--- a/src/options/features/media/MediaGallery.tsx
+++ b/src/options/features/media/MediaGallery.tsx
@@ -1,0 +1,387 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import type { MediaItemFilter, MediaItemRecord } from '@/core/models';
+import { countMediaItems, seedMediaItems } from '@/core/storage';
+import { useMediaItems } from '@/shared/hooks/useMediaItems';
+import { useTranslation } from '@/shared/i18n/useTranslation';
+
+import { useMediaStore } from './mediaStore';
+
+const PAGE_SIZE = 60;
+const SEED_TARGET = 1000;
+const TILE_WIDTH = 168;
+const TILE_HEIGHT = 188;
+const TILE_GAP = 12;
+
+const TYPE_ORDER: MediaItemFilter[] = ['all', 'audio', 'video', 'image'];
+
+function formatDuration(totalSeconds: number) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function MediaGallerySkeleton({ count }: { count: number }) {
+  return (
+    <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={index}
+          className="animate-pulse rounded-lg border border-slate-800/60 bg-slate-900/40 p-3"
+        >
+          <div className="h-24 w-full rounded-md bg-slate-800/70" />
+          <div className="mt-3 h-3 w-3/4 rounded bg-slate-800/60" />
+          <div className="mt-2 h-3 w-1/2 rounded bg-slate-800/40" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MediaTile({ item }: { item: MediaItemRecord }) {
+  return (
+    <div
+      aria-label={`${item.title} · ${item.type}`}
+      className="flex h-full w-full flex-col justify-between rounded-lg border border-slate-800/70 bg-slate-900/70 p-3 text-slate-100 shadow-sm"
+      role="listitem"
+    >
+      <div
+        className="relative flex h-24 items-center justify-center overflow-hidden rounded-md text-2xl font-semibold uppercase tracking-wide"
+        style={{
+          backgroundColor: item.dominantColor
+        }}
+      >
+        <div
+          className="absolute inset-0 opacity-70"
+          style={{
+            backgroundImage: `linear-gradient(135deg, ${item.dominantColor} 0%, ${item.accentColor} 100%)`
+          }}
+        />
+        <span className="relative drop-shadow-sm">{item.thumbnailLabel}</span>
+      </div>
+      <div className="mt-3 flex flex-col gap-1 text-xs">
+        <p className="truncate text-sm font-semibold">{item.title}</p>
+        <p className="text-slate-300">
+          {formatDuration(item.durationSeconds)} · {item.collection}
+        </p>
+        <p className="text-[11px] uppercase tracking-wide text-slate-400">{item.type}</p>
+      </div>
+    </div>
+  );
+}
+
+interface VirtualMediaGridProps {
+  items: MediaItemRecord[];
+  isLoading: boolean;
+  onEndReached?: () => void;
+  loadingLabel?: string;
+  initialViewport?: { width: number; height: number };
+  forcedColumnCount?: number;
+}
+
+export function VirtualMediaGrid({
+  items,
+  isLoading,
+  onEndReached,
+  loadingLabel,
+  initialViewport,
+  forcedColumnCount
+}: VirtualMediaGridProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreRef = useRef<number | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewport, setViewport] = useState(() => {
+    if (initialViewport) {
+      return initialViewport;
+    }
+    if (forcedColumnCount) {
+      return {
+        width: forcedColumnCount * (TILE_WIDTH + TILE_GAP),
+        height: 360
+      };
+    }
+    return { width: 0, height: 0 };
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const element = scrollRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      setViewport({ width: entry.contentRect.width, height: entry.contentRect.height });
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (items.length === 0) {
+      loadMoreRef.current = null;
+    }
+  }, [items.length]);
+
+  const handleScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  }, []);
+
+  const columnCount = useMemo(() => {
+    if (forcedColumnCount) {
+      return forcedColumnCount;
+    }
+    if (!viewport.width) {
+      return 3;
+    }
+    const calculated = Math.floor((viewport.width + TILE_GAP) / (TILE_WIDTH + TILE_GAP));
+    return Math.max(1, calculated);
+  }, [forcedColumnCount, viewport.width]);
+
+  const rowStride = TILE_HEIGHT + TILE_GAP;
+  const columnStride = TILE_WIDTH + TILE_GAP;
+  const totalRows = Math.ceil(items.length / columnCount);
+  const containerHeight = Math.max(0, totalRows * rowStride - TILE_GAP);
+  const containerWidth = columnCount * columnStride - TILE_GAP;
+  const visibleRowEstimate = viewport.height ? Math.ceil(viewport.height / rowStride) : 6;
+  const baseRow = Math.floor(scrollTop / rowStride);
+  const buffer = 2;
+  const startRow = Math.max(0, baseRow - buffer);
+  const endRow = Math.min(totalRows, baseRow + visibleRowEstimate + buffer);
+  const startIndex = startRow * columnCount;
+  const endIndex = Math.min(items.length, endRow * columnCount);
+
+  const visibleItems = useMemo(() => {
+    const subset: Array<{ item: MediaItemRecord; left: number; top: number }> = [];
+
+    for (let index = startIndex; index < endIndex; index += 1) {
+      const item = items[index];
+      if (!item) {
+        continue;
+      }
+      const row = Math.floor(index / columnCount);
+      const column = index % columnCount;
+      subset.push({
+        item,
+        left: column * columnStride,
+        top: row * rowStride
+      });
+    }
+
+    return subset;
+  }, [columnCount, columnStride, endIndex, items, rowStride, startIndex]);
+
+  useEffect(() => {
+    if (!onEndReached || isLoading || items.length === 0) {
+      return;
+    }
+
+    if (endRow >= totalRows - 1) {
+      if (loadMoreRef.current === items.length) {
+        return;
+      }
+      loadMoreRef.current = items.length;
+      onEndReached();
+    }
+  }, [endRow, isLoading, items.length, onEndReached, totalRows]);
+
+  return (
+    <div
+      aria-busy={isLoading}
+      className="relative h-[360px] overflow-y-auto"
+      onScroll={handleScroll}
+      ref={scrollRef}
+      role="list"
+    >
+      <div
+        className="relative"
+        style={{ height: containerHeight, minWidth: '100%' }}
+      >
+        <div style={{ height: containerHeight, width: containerWidth, position: 'relative' }}>
+          {visibleItems.map(({ item, left, top }) => (
+            <div
+              key={item.id}
+              className="absolute"
+              style={{
+                width: TILE_WIDTH,
+                height: TILE_HEIGHT,
+                transform: `translate3d(${left}px, ${top}px, 0)`
+              }}
+            >
+              <MediaTile item={item} />
+            </div>
+          ))}
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-slate-950/90 via-slate-950/40 to-transparent pb-3 pt-8 text-xs text-slate-300">
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 animate-ping rounded-full bg-emerald-400" />
+            <span>{loadingLabel ?? 'Loading…'}</span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function MediaGallery() {
+  const { t } = useTranslation();
+  const { mediaFilter, setMediaFilter } = useMediaStore();
+  const [items, setItems] = useState<MediaItemRecord[]>([]);
+  const [cursor, setCursor] = useState<number | null>(null);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [isSeeding, setIsSeeding] = useState(true);
+  const [seedError, setSeedError] = useState(false);
+
+  const { items: pageItems, nextCursor: incomingCursor, total, isLoading } = useMediaItems({
+    limit: PAGE_SIZE,
+    cursor,
+    type: mediaFilter
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function seed() {
+      try {
+        const current = await countMediaItems();
+        if (cancelled) {
+          return;
+        }
+        if (current < SEED_TARGET) {
+          await seedMediaItems(SEED_TARGET);
+        }
+      } catch (error) {
+        console.error('[ai-companion] failed to seed media items', error);
+        if (!cancelled) {
+          setSeedError(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsSeeding(false);
+        }
+      }
+    }
+
+    seed();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (cursor === null) {
+      setItems(pageItems);
+    } else if (pageItems.length) {
+      setItems((previous) => {
+        const existing = new Set(previous.map((item) => item.id));
+        const appended = pageItems.filter((item) => !existing.has(item.id));
+        if (appended.length === 0) {
+          return previous;
+        }
+        return [...previous, ...appended];
+      });
+    }
+    setNextCursor(incomingCursor ?? null);
+  }, [cursor, incomingCursor, pageItems]);
+
+  useEffect(() => {
+    if (!isLoading && !isSeeding) {
+      setHasLoaded(true);
+    }
+  }, [isLoading, isSeeding]);
+
+  useEffect(() => {
+    setItems([]);
+    setCursor(null);
+    setNextCursor(null);
+    setHasLoaded(false);
+  }, [mediaFilter]);
+
+  const handleEndReached = useCallback(() => {
+    if (isLoading || nextCursor === null || cursor === nextCursor) {
+      return;
+    }
+    setCursor(nextCursor);
+  }, [cursor, isLoading, nextCursor]);
+
+  const showSkeleton = !hasLoaded && (isLoading || isSeeding);
+  const visibleCount = Math.min(items.length, total);
+  const countLabel = t('options.mediaGalleryCount', { visible: visibleCount, total }) ?? `Showing ${visibleCount} of ${total}`;
+  const filterLabel = t('options.mediaGalleryFilterLabel') ?? 'Filter by type';
+  const loadingMoreLabel = t('options.mediaGalleryLoadingMore') ?? 'Loading more…';
+  const emptyLabel = t('options.mediaGalleryEmpty') ?? 'No media items yet.';
+  const seedErrorLabel = t('options.mediaGallerySeedError') ?? 'Demo media items could not be prepared. Reload the dashboard to retry.';
+
+  let body: ReactNode;
+
+  if (showSkeleton) {
+    body = <MediaGallerySkeleton count={12} />;
+  } else if (items.length === 0) {
+    body = (
+      <div className="mt-4 rounded-lg border border-slate-800/70 bg-slate-950/40 p-6 text-sm text-slate-300">
+        <p>{emptyLabel}</p>
+      </div>
+    );
+  } else {
+    body = (
+      <div className="mt-4 rounded-lg border border-slate-800/70 bg-slate-950/40 p-3">
+        <VirtualMediaGrid
+          initialViewport={{ width: 720, height: 360 }}
+          isLoading={isLoading}
+          items={items}
+          loadingLabel={loadingMoreLabel}
+          onEndReached={handleEndReached}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-emerald-200">
+            {t('options.mediaGalleryHeading') ?? 'Media gallery'}
+          </h3>
+          <p className="text-xs text-slate-300">
+            {t('options.mediaGalleryDescription') ?? 'Browse recent voice captures and uploads with virtualised thumbnails.'}
+          </p>
+        </div>
+        <div className="flex flex-col items-stretch gap-2 text-xs text-slate-300 sm:flex-row sm:items-center">
+          <label className="font-semibold uppercase tracking-wide text-slate-400" htmlFor="media-gallery-filter">
+            {filterLabel}
+          </label>
+          <select
+            className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+            id="media-gallery-filter"
+            onChange={(event) => setMediaFilter(event.target.value as MediaItemFilter)}
+            value={mediaFilter}
+          >
+            {TYPE_ORDER.map((type) => (
+              <option key={type} value={type}>
+                {t(`options.mediaGalleryFilter.${type}` as const) ?? type}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <p className="mt-3 text-xs text-slate-400">{countLabel}</p>
+      {body}
+      {seedError ? <p className="mt-3 text-xs text-rose-400">{seedErrorLabel}</p> : null}
+    </div>
+  );
+}

--- a/src/options/features/media/MediaSection.tsx
+++ b/src/options/features/media/MediaSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '@/shared/i18n/useTranslation';
 import { MediaOverlay } from '@/ui/components/MediaOverlay';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/ui/components/Modal';
 
+import { MediaGallery } from './MediaGallery';
 import { useMediaStore } from './mediaStore';
 
 export function MediaSection() {
@@ -49,7 +50,7 @@ export function MediaSection() {
                 type="checkbox"
               />
               <span className="text-sm text-slate-200">
-                {t('options.mediaAutoDownloadLabel') ?? 'Automatically download response audio when available'}
+                {t('options.mediaVoiceAutoDownload') ?? 'Automatically download response audio when available'}
               </span>
             </label>
             <label className="flex items-start gap-3">
@@ -60,7 +61,7 @@ export function MediaSection() {
                 type="checkbox"
               />
               <span className="text-sm text-slate-200">
-                {t('options.mediaAdvancedVoiceLabel') ?? 'Enable advanced voice mode with layered prompts'}
+                {t('options.mediaVoiceAdvanced') ?? 'Enable advanced voice mode with layered prompts'}
               </span>
             </label>
             <label className="flex items-start gap-3">
@@ -71,12 +72,12 @@ export function MediaSection() {
                 type="checkbox"
               />
               <span className="text-sm text-slate-200">
-                {t('options.mediaSyncLabel') ?? 'Synchronize voice presets across signed-in browsers'}
+                {t('options.mediaVoiceSync') ?? 'Synchronize voice presets across signed-in browsers'}
               </span>
             </label>
             <div className="flex flex-col gap-2">
               <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="voice-select">
-                {t('options.mediaVoiceSelectLabel') ?? 'Default voice'}
+                {t('options.mediaVoiceSelect') ?? 'Default voice'}
               </label>
               <select
                 className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
@@ -106,15 +107,7 @@ export function MediaSection() {
             </button>
           </div>
         </div>
-        <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
-          <h3 className="text-base font-semibold text-emerald-200">{t('options.mediaGuidanceHeading') ?? 'Accessibility & sync'}</h3>
-          <ul className="mt-4 space-y-3 text-sm text-slate-200">
-            <li>{t('options.mediaGuidanceKeyboard') ?? 'All controls remain keyboard accessible with focus outlines.'}</li>
-            <li>{t('options.mediaGuidanceScreenReader') ?? 'Announcements mirror playback state for screen-readers.'}</li>
-            <li>{t('options.mediaGuidanceRtl') ?? 'RTL layouts flip toolbar affordances automatically.'}</li>
-            <li>{t('options.mediaGuidanceSync') ?? 'Voice preferences sync when signed into Chrome with storage permissions.'}</li>
-          </ul>
-        </div>
+        <MediaGallery />
       </div>
 
       <MediaOverlay labelledBy="media-preview-heading" onClose={() => setPreviewOpen(false)} open={previewOpen}>

--- a/src/options/features/media/mediaStore.ts
+++ b/src/options/features/media/mediaStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import type { MediaItemFilter } from '@/core/models';
+
 interface MediaState {
   autoDownloadEnabled: boolean;
   advancedVoiceMode: boolean;
@@ -7,12 +9,14 @@ interface MediaState {
   syncDraftsEnabled: boolean;
   previewOpen: boolean;
   modalOpen: boolean;
+  mediaFilter: MediaItemFilter;
   setAutoDownloadEnabled: (value: boolean) => void;
   setAdvancedVoiceMode: (value: boolean) => void;
   setSelectedVoice: (voice: string) => void;
   setSyncDraftsEnabled: (value: boolean) => void;
   setPreviewOpen: (value: boolean) => void;
   setModalOpen: (value: boolean) => void;
+  setMediaFilter: (filter: MediaItemFilter) => void;
 }
 
 export const useMediaStore = create<MediaState>((set) => ({
@@ -22,10 +26,12 @@ export const useMediaStore = create<MediaState>((set) => ({
   syncDraftsEnabled: true,
   previewOpen: false,
   modalOpen: false,
+  mediaFilter: 'all',
   setAutoDownloadEnabled: (value) => set({ autoDownloadEnabled: value }),
   setAdvancedVoiceMode: (value) => set({ advancedVoiceMode: value }),
   setSelectedVoice: (voice) => set({ selectedVoice: voice }),
   setSyncDraftsEnabled: (value) => set({ syncDraftsEnabled: value }),
   setPreviewOpen: (value) => set({ previewOpen: value }),
-  setModalOpen: (value) => set({ modalOpen: value })
+  setModalOpen: (value) => set({ modalOpen: value }),
+  setMediaFilter: (filter) => set({ mediaFilter: filter })
 }));

--- a/src/shared/hooks/useMediaItems.ts
+++ b/src/shared/hooks/useMediaItems.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { liveQuery } from 'dexie';
+
+import type { MediaItemFilter, MediaItemRecord } from '@/core/models';
+import { listMediaItems } from '@/core/storage';
+
+interface UseMediaItemsOptions {
+  limit?: number;
+  cursor?: number | null;
+  type?: MediaItemFilter;
+}
+
+interface UseMediaItemsState {
+  items: MediaItemRecord[];
+  nextCursor: number | null;
+  total: number;
+  isLoading: boolean;
+}
+
+const DEFAULT_STATE: UseMediaItemsState = {
+  items: [],
+  nextCursor: null,
+  total: 0,
+  isLoading: true
+};
+
+export function useMediaItems(options: UseMediaItemsOptions = {}): UseMediaItemsState {
+  const { limit = 60, cursor = null, type = 'all' } = options;
+  const [state, setState] = useState<UseMediaItemsState>(DEFAULT_STATE);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setState((previous) => ({ ...previous, isLoading: true }));
+
+    const subscription = liveQuery(() => listMediaItems({ limit, cursor, type })).subscribe({
+      next: (value) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          items: value.items,
+          nextCursor: value.nextCursor,
+          total: value.total,
+          isLoading: false
+        });
+      },
+      error: (error) => {
+        console.error('[ai-companion] media items live query failed', error);
+        if (cancelled) {
+          return;
+        }
+        setState((previous) => ({ ...previous, isLoading: false }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+    };
+  }, [limit, cursor, type]);
+
+  return state;
+}

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -175,6 +175,27 @@
       "markUnviewedAria": "Restore guide {{title}}",
       "viewedBadge": "Viewed"
     },
+    "mediaHeading": "Audio & sync workspace",
+    "mediaDescription": "Configure voice playback and cross-device capture defaults.",
+    "mediaVoiceHeading": "Voice controls",
+    "mediaVoiceDescription": "Select a default narration voice and configure advanced capture behaviours.",
+    "mediaVoiceAutoDownload": "Automatically download response audio when available",
+    "mediaVoiceAdvanced": "Enable advanced voice mode with layered prompts",
+    "mediaVoiceSync": "Synchronise voice presets across signed-in browsers",
+    "mediaVoiceSelect": "Default voice",
+    "mediaGalleryHeading": "Media gallery",
+    "mediaGalleryDescription": "Browse recent voice captures and uploads with virtualised thumbnails.",
+    "mediaGalleryFilterLabel": "Filter",
+    "mediaGalleryFilter": {
+      "all": "All media",
+      "audio": "Audio",
+      "video": "Video",
+      "image": "Images"
+    },
+    "mediaGalleryCount": "Showing {{visible}} of {{total}} media items",
+    "mediaGalleryLoadingMore": "Loading more media…",
+    "mediaGalleryEmpty": "No media items yet. Capture or upload audio to see it here.",
+    "mediaGallerySeedError": "Demo media items could not be prepared. Reload the dashboard to retry.",
     "encryption": {
       "heading": "Passphrase & sync encryption",
       "description": "Protect Dexie sync snapshots with an optional passphrase. The key never leaves this device.",

--- a/src/shared/i18n/locales/nl/common.json
+++ b/src/shared/i18n/locales/nl/common.json
@@ -175,6 +175,27 @@
       "markUnviewedAria": "Herstel gids {{title}}",
       "viewedBadge": "Bekeken"
     },
+    "mediaHeading": "Audio- & syncwerkruimte",
+    "mediaDescription": "Configureer voice-weergave en standaardinstellingen voor cross-device captures.",
+    "mediaVoiceHeading": "Voice-bediening",
+    "mediaVoiceDescription": "Kies een standaardstem en stel geavanceerde capture-gedragingen in.",
+    "mediaVoiceAutoDownload": "Audio automatisch downloaden zodra het beschikbaar is",
+    "mediaVoiceAdvanced": "Geavanceerde voicemodus met gelaagde prompts inschakelen",
+    "mediaVoiceSync": "Voice-presets synchroniseren tussen ingelogde browsers",
+    "mediaVoiceSelect": "Standaardstem",
+    "mediaGalleryHeading": "Mediagalerij",
+    "mediaGalleryDescription": "Blader door recente voice-captures en uploads met een virtueel raster.",
+    "mediaGalleryFilterLabel": "Filter",
+    "mediaGalleryFilter": {
+      "all": "Alle media",
+      "audio": "Audio",
+      "video": "Video",
+      "image": "Afbeeldingen"
+    },
+    "mediaGalleryCount": "{{visible}} van {{total}} media-items zichtbaar",
+    "mediaGalleryLoadingMore": "Meer media laden…",
+    "mediaGalleryEmpty": "Nog geen media-items. Maak een capture of upload audio om ze hier te tonen.",
+    "mediaGallerySeedError": "Voorbeeldmedia konden niet worden voorbereid. Herlaad het dashboard om het opnieuw te proberen.",
     "encryption": {
       "heading": "Wachtwoordzin & sync-encryptie",
       "description": "Beveilig Dexie-syncsnapshots met een optionele wachtwoordzin. De sleutel verlaat dit apparaat nooit.",

--- a/tests/mocks/inMemoryDb.ts
+++ b/tests/mocks/inMemoryDb.ts
@@ -3,6 +3,7 @@ import type {
   ConversationRecord,
   FolderItemRecord,
   FolderRecord,
+  MediaItemRecord,
   MessageRecord,
   PromptChainRecord
 } from '@/core/models';
@@ -218,6 +219,12 @@ class MessageTable extends InMemoryTable<MessageRecord> {
   }
 }
 
+class MediaItemsTable extends InMemoryTable<MediaItemRecord> {
+  constructor() {
+    super('sortKey');
+  }
+}
+
 class ConversationTable extends InMemoryTable<ConversationRecord> {
   constructor() {
     super('updatedAt');
@@ -301,6 +308,7 @@ const promptChains = new PromptChainTable();
 const folders = new FolderTable();
 const folderItems = new FolderItemsTable();
 const metadata = new MetadataTable();
+const mediaItems = new MediaItemsTable();
 
 export const db = {
   conversations,
@@ -310,6 +318,7 @@ export const db = {
   folders,
   folderItems,
   metadata,
+  mediaItems,
   async transaction(_mode: string, ...args: unknown[]) {
     const maybeCallback = args[args.length - 1];
     if (typeof maybeCallback === 'function') {
@@ -326,7 +335,8 @@ export async function resetDatabase() {
     promptChains.clear(),
     folders.clear(),
     folderItems.clear(),
-    metadata.clear()
+    metadata.clear(),
+    mediaItems.clear()
   ]);
 }
 
@@ -337,5 +347,6 @@ export const __stores = {
   promptChains,
   folders,
   folderItems,
-  metadata
+  metadata,
+  mediaItems
 };

--- a/tests/mocks/inMemoryDb.ts
+++ b/tests/mocks/inMemoryDb.ts
@@ -13,17 +13,35 @@ export const ENCRYPTION_METADATA_KEY = 'encryption';
 
 type RecordWithId = { id: string };
 
+type LimitedResult<T extends RecordWithId> = {
+  toArray(): Promise<T[]>;
+};
+
+type DirectionalResult<T extends RecordWithId> = {
+  limit(limit: number): LimitedResult<T>;
+  toArray(): Promise<T[]>;
+};
+
 type WhereResult<T extends RecordWithId> = {
   count(): Promise<number>;
   toArray(): Promise<T[]>;
   delete(): Promise<void>;
   and(predicate: (item: T) => boolean): WhereResult<T>;
   first(): Promise<T | undefined>;
+  reverse(): DirectionalResult<T>;
+  limit(limit: number): LimitedResult<T>;
 };
 
 type WhereQuery<T extends RecordWithId> = {
   equals(value: unknown): WhereResult<T>;
   anyOf(values: readonly unknown[]): WhereResult<T>;
+  below(value: unknown): WhereResult<T>;
+  between(
+    lower: unknown,
+    upper: unknown,
+    includeLower?: boolean,
+    includeUpper?: boolean
+  ): WhereResult<T>;
 };
 
 type OrderQuery<T extends RecordWithId> = {
@@ -46,6 +64,7 @@ type MutableTable<T extends RecordWithId> = {
   clear(): Promise<void>;
   where<K extends keyof T>(field: K): WhereQuery<T>;
   orderBy<K extends keyof T>(field: K): OrderQuery<T>;
+  count(): Promise<number>;
 };
 
 function clone<T>(value: T): T {
@@ -54,14 +73,18 @@ function clone<T>(value: T): T {
 
 function createWhereResult<T extends RecordWithId>(
   table: InMemoryTable<T>,
-  items: T[]
+  items: T[],
+  sortField?: keyof T
 ): WhereResult<T> {
+  const sortAscending = () => table.sortItems(items, sortField, false);
+  const sortDescending = () => table.sortItems(items, sortField, true);
+
   return {
     async count() {
       return items.length;
     },
     async toArray() {
-      return items.map((item) => clone(item));
+      return sortAscending();
     },
     async delete() {
       for (const item of items) {
@@ -70,11 +93,32 @@ function createWhereResult<T extends RecordWithId>(
     },
     and(predicate: (item: T) => boolean) {
       const filtered = items.filter((item) => predicate(item));
-      return createWhereResult(table, filtered);
+      return createWhereResult(table, filtered, sortField);
     },
     async first() {
-      const [first] = items;
-      return first ? clone(first) : undefined;
+      const [first] = sortAscending();
+      return first ?? undefined;
+    },
+    reverse() {
+      return {
+        limit(limit: number) {
+          return {
+            async toArray() {
+              return sortDescending().slice(0, limit);
+            }
+          } satisfies LimitedResult<T>;
+        },
+        async toArray() {
+          return sortDescending();
+        }
+      } satisfies DirectionalResult<T>;
+    },
+    limit(limit: number) {
+      return {
+        async toArray() {
+          return sortAscending().slice(0, limit);
+        }
+      } satisfies LimitedResult<T>;
     }
   };
 }
@@ -83,6 +127,48 @@ class InMemoryTable<T extends RecordWithId> implements MutableTable<T> {
   protected store = new Map<string, T>();
 
   constructor(private readonly sortFallback: keyof T | null = null) {}
+
+  private resolveSortValue(item: T, field?: keyof T) {
+    if (field) {
+      const value = (item as Record<string, unknown>)[field as string];
+      if (value !== undefined) {
+        return value;
+      }
+    }
+
+    if (this.sortFallback) {
+      return (item as Record<string, unknown>)[this.sortFallback as string];
+    }
+
+    return field ? (item as Record<string, unknown>)[field as string] : undefined;
+  }
+
+  sortItems(items: T[], sortField?: keyof T, descending = false) {
+    const sorted = [...items].sort((a, b) => {
+      const aValue = this.resolveSortValue(a, sortField);
+      const bValue = this.resolveSortValue(b, sortField);
+
+      if (aValue === bValue) {
+        return 0;
+      }
+
+      if (aValue == null) {
+        return 1;
+      }
+
+      if (bValue == null) {
+        return -1;
+      }
+
+      return aValue > bValue ? 1 : -1;
+    });
+
+    if (descending) {
+      sorted.reverse();
+    }
+
+    return sorted.map((item) => clone(item));
+  }
 
   async add(record: T) {
     return this.put(record);
@@ -154,50 +240,72 @@ class InMemoryTable<T extends RecordWithId> implements MutableTable<T> {
     this.store.clear();
   }
 
+  async count() {
+    return this.store.size;
+  }
+
   where<K extends keyof T>(field: K): WhereQuery<T> {
+    const values = () => [...this.store.values()];
+    const toNumber = (value: unknown, fallback: number) =>
+      typeof value === 'number' ? value : fallback;
+
     return {
       equals: (value: unknown) => {
-        const items = [...this.store.values()].filter((item) => (item as any)[field] === value);
-        return createWhereResult(this, items);
+        const items = values().filter((item) => (item as any)[field] === value);
+        return createWhereResult(this, items, field);
       },
-      anyOf: (values: readonly unknown[]) => {
-        const set = new Set(values);
-        const items = [...this.store.values()].filter((item) => set.has((item as any)[field]));
-        return createWhereResult(this, items);
+      anyOf: (incoming: readonly unknown[]) => {
+        const set = new Set(incoming);
+        const items = values().filter((item) => set.has((item as any)[field]));
+        return createWhereResult(this, items, field);
+      },
+      below: (value: unknown) => {
+        const upper = toNumber(value, Number.POSITIVE_INFINITY);
+        const items = values().filter((item) => {
+          const current = (item as any)[field];
+          return typeof current === 'number' && current < upper;
+        });
+        return createWhereResult(this, items, field);
+      },
+      between: (
+        lower: unknown,
+        upper: unknown,
+        includeLower = true,
+        includeUpper = true
+      ) => {
+        const lowerBound = toNumber(lower, Number.NEGATIVE_INFINITY);
+        const upperBound = toNumber(upper, Number.POSITIVE_INFINITY);
+        const items = values().filter((item) => {
+          const current = (item as any)[field];
+          if (typeof current !== 'number') {
+            return false;
+          }
+          const lowerPass = includeLower ? current >= lowerBound : current > lowerBound;
+          const upperPass = includeUpper ? current <= upperBound : current < upperBound;
+          return lowerPass && upperPass;
+        });
+        return createWhereResult(this, items, field);
       }
-    };
+    } satisfies WhereQuery<T>;
   }
 
   orderBy<K extends keyof T>(field: K): OrderQuery<T> {
     const sortField = field;
-    const fallback = this.sortFallback;
-
-    const sortValues = () =>
-      [...this.store.values()].sort((a, b) => {
-        const aValue = (a as any)[sortField] ?? (fallback ? (a as any)[fallback] : undefined);
-        const bValue = (b as any)[sortField] ?? (fallback ? (b as any)[fallback] : undefined);
-        if (aValue === bValue) return 0;
-        return aValue > bValue ? 1 : -1;
-      });
+    const values = () => [...this.store.values()];
 
     return {
       reverse: () => ({
         limit: (limit: number) => ({
           toArray: async () => {
-            return sortValues()
-              .reverse()
-              .slice(0, limit)
-              .map((item) => clone(item));
+            return this.sortItems(values(), sortField, true).slice(0, limit);
           }
         }),
         toArray: async () => {
-          return sortValues()
-            .reverse()
-            .map((item) => clone(item));
+          return this.sortItems(values(), sortField, true);
         }
       }),
       toArray: async () => {
-        return sortValues().map((item) => clone(item));
+        return this.sortItems(values(), sortField, false);
       }
     };
   }
@@ -222,6 +330,74 @@ class MessageTable extends InMemoryTable<MessageRecord> {
 class MediaItemsTable extends InMemoryTable<MediaItemRecord> {
   constructor() {
     super('sortKey');
+  }
+
+  override where(field: keyof MediaItemRecord | '[type+sortKey]'): WhereQuery<MediaItemRecord> {
+    if (field === '[type+sortKey]') {
+      const values = () => [...this.store.values()];
+
+      return {
+        equals: (value: unknown) => {
+          const [type, sortKey] = Array.isArray(value) ? value : [];
+          const items = values().filter(
+            (item) => item.type === type && item.sortKey === sortKey
+          );
+          return createWhereResult(this, items, 'sortKey');
+        },
+        anyOf: (incoming: readonly unknown[]) => {
+          const normalized = incoming
+            .map((value) => (Array.isArray(value) ? value : []))
+            .filter((entry): entry is [MediaItemRecord['type'], number] => entry.length === 2);
+          const items = values().filter((item) =>
+            normalized.some(([type, sortKey]) => item.type === type && item.sortKey === sortKey)
+          );
+          return createWhereResult(this, items, 'sortKey');
+        },
+        below: (value: unknown) => {
+          if (!Array.isArray(value) || value.length < 2) {
+            return createWhereResult(this, [], 'sortKey');
+          }
+          const [type, sortKey] = value as [MediaItemRecord['type'], number];
+          const items = values().filter(
+            (item) => item.type === type && item.sortKey < sortKey
+          );
+          return createWhereResult(this, items, 'sortKey');
+        },
+        between: (
+          lower: unknown,
+          upper: unknown,
+          includeLower = true,
+          includeUpper = true
+        ) => {
+          const lowerTuple = Array.isArray(lower) ? lower : [];
+          const upperTuple = Array.isArray(upper) ? upper : [];
+          const type = (lowerTuple[0] ?? upperTuple[0]) as MediaItemRecord['type'] | undefined;
+          if (!type) {
+            return createWhereResult(this, [], 'sortKey');
+          }
+
+          const lowerValue =
+            typeof lowerTuple[1] === 'number' ? lowerTuple[1] : Number.NEGATIVE_INFINITY;
+          const upperValue =
+            typeof upperTuple[1] === 'number' ? upperTuple[1] : Number.POSITIVE_INFINITY;
+
+          const items = values().filter((item) => {
+            if (item.type !== type) {
+              return false;
+            }
+
+            const current = item.sortKey;
+            const lowerPass = includeLower ? current >= lowerValue : current > lowerValue;
+            const upperPass = includeUpper ? current <= upperValue : current < upperValue;
+            return lowerPass && upperPass;
+          });
+
+          return createWhereResult(this, items, 'sortKey');
+        }
+      } satisfies WhereQuery<MediaItemRecord>;
+    }
+
+    return super.where(field as keyof MediaItemRecord);
   }
 }
 
@@ -256,7 +432,7 @@ class FolderItemsTable extends InMemoryTable<FolderItemRecord> {
           const items = [...this.store.values()].filter(
             (item) => item.itemType === itemType && item.itemId === itemId
           );
-          return createWhereResult(this, items);
+          return createWhereResult(this, items, 'updatedAt');
         },
         anyOf: (values: readonly unknown[]) => {
           const normalized = values
@@ -265,8 +441,10 @@ class FolderItemsTable extends InMemoryTable<FolderItemRecord> {
           const items = [...this.store.values()].filter((item) =>
             normalized.some(([type, id]) => item.itemType === type && item.itemId === id)
           );
-          return createWhereResult(this, items);
-        }
+          return createWhereResult(this, items, 'updatedAt');
+        },
+        below: () => createWhereResult(this, [], 'updatedAt'),
+        between: () => createWhereResult(this, [], 'updatedAt')
       } satisfies WhereQuery<FolderItemRecord>;
     }
 

--- a/tests/options/mediaGallery.spec.ts
+++ b/tests/options/mediaGallery.spec.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { MediaItemRecord } from '../../src/core/models';
+import { listMediaItems, resetDatabase, seedMediaItems } from '../../src/core/storage';
+import { VirtualMediaGrid } from '../../src/options/features/media/MediaGallery';
+
+async function gatherMediaItems(limit: number) {
+  const items: MediaItemRecord[] = [];
+  let cursor: number | null = null;
+
+  do {
+    const { items: page, nextCursor } = await listMediaItems({ limit, cursor });
+    items.push(...page);
+    cursor = nextCursor;
+  } while (cursor !== null);
+
+  return items;
+}
+
+async function runMediaGalleryPerfCheck() {
+  await resetDatabase();
+  await seedMediaItems(1000);
+
+  const items = await gatherMediaItems(200);
+
+  assert.ok(items.length >= 1000, `expected at least 1000 items, received ${items.length}`);
+
+  const start = performance.now();
+  const markup = renderToStaticMarkup(
+    createElement(VirtualMediaGrid, {
+      forcedColumnCount: 4,
+      initialViewport: { width: 720, height: 480 },
+      isLoading: false,
+      items,
+      loadingLabel: 'Loading more…'
+    })
+  );
+  const duration = performance.now() - start;
+
+  const renderedTiles = (markup.match(/role="listitem"/g) ?? []).length;
+
+  console.log(
+    `[perf] media gallery rendered ${renderedTiles} tiles from ${items.length} records in ${duration.toFixed(2)}ms`
+  );
+
+  assert.ok(renderedTiles <= 120, `expected virtual grid to render <=120 tiles, got ${renderedTiles}`);
+  assert.ok(duration < 300, `expected render <300ms, got ${duration.toFixed(2)}ms`);
+}
+
+try {
+  await runMediaGalleryPerfCheck();
+} catch (error) {
+  console.error('[tests] media gallery perf check failed', error);
+  process.exitCode = 1;
+}

--- a/tests/runAll.ts
+++ b/tests/runAll.ts
@@ -13,6 +13,7 @@ async function runSequentially() {
   await import('./shared/bubbleLauncherStore.spec');
   await import('./shared/syncEncryptionClient.spec');
   await import('./shared/theme/themePreference.spec');
+  await import('./options/mediaGallery.spec');
 }
 
 runSequentially()


### PR DESCRIPTION
## Summary
- add a Dexie `media_items` table with seeding helpers and a `useMediaItems` hook
- replace the options media card with a virtualized gallery that supports filters, skeletons, and batching
- add a performance regression test and document the media QA workflow updates

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e6b77ef38c833384b979cad36f76bc